### PR TITLE
determine tag depending on content-type

### DIFF
--- a/src/components/NFTList.js
+++ b/src/components/NFTList.js
@@ -197,6 +197,11 @@ export default function NFTList(props) {
     props.loader(false);
     props.error(e);
   }
+  const getContentType = async url => {
+    let response = await fetch(url)
+    let contentType = response.headers.get("Content-Type");
+    return contentType
+  }
   const icpbunnyimg = i => {
     const icbstorage = ['efqhu-yqaaa-aaaaf-qaeda-cai',
     'ecrba-viaaa-aaaaf-qaedq-cai',
@@ -374,7 +379,7 @@ export default function NFTList(props) {
                     </SnackbarButton>
                   </TableCell>
                   <TableCell>
-                    <a href={getNftLink(nft)} target="_blank" rel="noreferrer"><img id={"img-"+nft.id} alt={compressAddress(nft.id)} src={getNftImg(nft)} style={{width:64}} /></a>
+                    <a href={getNftLink(nft)} target="_blank" rel="noreferrer"><object data={getNftImg(nft)} id={"img-"+nft.id} width="64">{compressAddress(nft.id)}</object></a>
                   </TableCell>
                   <TableCell>
                     

--- a/src/components/NFTList.js
+++ b/src/components/NFTList.js
@@ -197,6 +197,14 @@ export default function NFTList(props) {
     props.loader(false);
     props.error(e);
   }
+  const displayNFT = async nft => {
+    let contentType = await getContentType(getNftLink(nft));
+    if (contentType === "video/mp4") {
+      return (<a href={getNftLink(nft)} target="_blank" rel="noreferrer"><video src={getNftImg(nft)} autoPlay loop preload muted playsInline style={{width:"64px"}} >{compressAddress(nft.id)}</video></a>)
+    } else {
+      return (<a href={getNftLink(nft)} target="_blank" rel="noreferrer" style={{display:'block'}}><object data={getNftImg(nft)} id={"img-"+nft.id} width="64" style={{pointerEvents:'none'}}>{compressAddress(nft.id)}</object></a>)
+    }
+  }
   const getContentType = async url => {
     let response = await fetch(url)
     let contentType = response.headers.get("Content-Type");

--- a/src/components/NFTList.js
+++ b/src/components/NFTList.js
@@ -379,7 +379,7 @@ export default function NFTList(props) {
                     </SnackbarButton>
                   </TableCell>
                   <TableCell>
-                    <a href={getNftLink(nft)} target="_blank" rel="noreferrer"><object data={getNftImg(nft)} id={"img-"+nft.id} width="64">{compressAddress(nft.id)}</object></a>
+                    <a href={getNftLink(nft)} target="_blank" rel="noreferrer" style={{display:'block'}}><object data={getNftImg(nft)} id={"img-"+nft.id} width="64" style={{pointerEvents:'none'}}>{compressAddress(nft.id)}</object></a>
                   </TableCell>
                   <TableCell>
                     


### PR DESCRIPTION
this change allows different media types to be displayed in stoic wallet (mp4 video, animated svg's that pull in external resources etc.) why still supporting the status quo. 

an even better solution would be to use the `getContentType` to display the media in the best possible way, unfortunately i'm not too familiar with react so i only provided the function to determine the content type and render an `<object>` or `<video>` tag accordingly.