### PR TITLE
Fix cycles top-up (cmc_notify) + update tx explorer links

### DIFF
--- a/src/components/Transactions.js
+++ b/src/components/Transactions.js
@@ -85,7 +85,7 @@ export default function Transactions(props) {
                             Fee
                             <br />(
                             <a
-                              href={'https://ic.house/ICP/tx/' + tx.hash}
+                              href={'https://dashboard.internetcomputer.org/transaction/' + tx.hash}
                               target="_blank"
                               rel="noreferrer"
                             >
@@ -102,7 +102,7 @@ export default function Transactions(props) {
                             from {tx.from}
                             <br />(
                             <a
-                              href={'https://ic.house/ICP/tx/' + tx.hash}
+                              href={'https://dashboard.internetcomputer.org/transaction/' + tx.hash}
                               target="_blank"
                               rel="noreferrer"
                             >

--- a/src/ic/candid/cycles.did.js
+++ b/src/ic/candid/cycles.did.js
@@ -28,7 +28,27 @@ export default ({ IDL }) => {
     'ToppedUp' : IDL.Null,
   });
   const Result = IDL.Variant({ 'Ok' : CyclesResponse, 'Err' : IDL.Text });
+  // New cmc_notify flow (replaces the deprecated ledger_notify / transaction_notification).
+  const NotifyTopUpArg = IDL.Record({
+    'block_index' : IDL.Nat64,
+    'canister_id' : IDL.Principal,
+  });
+  const NotifyError = IDL.Variant({
+    'Refunded' : IDL.Record({
+      'block_index' : IDL.Opt(IDL.Nat64),
+      'reason' : IDL.Text,
+    }),
+    'InvalidTransaction' : IDL.Text,
+    'Other' : IDL.Record({
+      'error_message' : IDL.Text,
+      'error_code' : IDL.Nat64,
+    }),
+    'Processing' : IDL.Null,
+    'TransactionTooOld' : IDL.Nat64,
+  });
+  const NotifyTopUpResult = IDL.Variant({ 'Ok' : IDL.Nat, 'Err' : NotifyError });
   return IDL.Service({
+    'notify_top_up' : IDL.Func([NotifyTopUpArg], [NotifyTopUpResult], []),
     'get_average_icp_xdr_conversion_rate' : IDL.Func(
         [],
         [IcpXdrConversionRateCertifiedResponse],

--- a/src/ic/extjs.js
+++ b/src/ic/extjs.js
@@ -481,15 +481,22 @@ class ExtConnection {
                 amount: {e8s: amount},
               };
               const block = await api.send_dfx(args);
-              args = {
-                block_height: block,
-                max_fee: {e8s: fee},
-                from_subaccount: [getSubAccountArray(from_sa ?? 0)],
-                to_subaccount: [getSubAccountArray(_to_sub)],
-                to_canister: Principal.fromText(CYCLES_MINTING_CANISTER_ID),
-              };
-              await api.notify_dfx(args);
-              return true; // Success
+              // New cmc_notify flow: notify the Cycles Minting Canister directly via
+              // notify_top_up, replacing the deprecated ledger notify_dfx ->
+              // transaction_notification push. See:
+              // https://forum.dfinity.org/t/deprecating-the-ledger-notify-flow-for-minting-cycles-in-favor-of-cmc-notify/42502
+              const cmc = this.canister(CYCLES_MINTING_CANISTER_ID, cyclesIDL);
+              const notifyRes = await cmc.notify_top_up({
+                block_index: BigInt(block),
+                canister_id: Principal.fromText(canister),
+              });
+              if (notifyRes.Err !== undefined) {
+                throw new Error(
+                  'Cycles top-up notification failed: ' +
+                    JSON.stringify(notifyRes.Err, (k, v) => (typeof v === 'bigint' ? v.toString() : v)),
+                );
+              }
+              return true; // notifyRes.Ok holds the cycles minted
             } catch (e) {
               throw e; // or handle error as appropriate
             }


### PR DESCRIPTION
## What
Two maintenance fixes:

### 1. Cycle top-up → CMC `notify_top_up` (fixes #53)
The "Top-up your canister" flow used the **deprecated** ledger `notify_dfx` → CMC `transaction_notification` push. This switches to the current **`transfer → cmc_notify`** flow: after the ICP `send_dfx` transfer, it calls the CMC's **`notify_top_up({ block_index, canister_id })`** directly. Adds `notify_top_up` + `NotifyError` to `src/ic/candid/cycles.did.js`.

### 2. Transaction explorer links (fixes #21)
"View Transaction" links now point at `https://dashboard.internetcomputer.org/transaction/…` (the repo had moved ic.rocks → `ic.house`, which is also unreliable).

## ⚠️ Not built/tested in CI here
This environment can't install the repo's `@psychedelic/dab-js` dependency (it's on **private GitHub Packages**, needs a `PAT` with `read:packages` for the `@psychedelic` org), so I couldn't run a local build. Please:
- [ ] Build locally (`NODE_OPTIONS=--openssl-legacy-provider`).
- [ ] Do a small real top-up to confirm `notify_top_up` works end-to-end.

## Refs
- https://forum.dfinity.org/t/deprecating-the-ledger-notify-flow-for-minting-cycles-in-favor-of-cmc-notify/42502

_Opened by the agentops control plane._