### PR TITLE
docs: add local development instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,39 @@
 # Stoic Wallet
+
 Example repo of a simple Stoic implementation: https://github.com/Toniq-Labs/stoic-identity.
 
 Note: the redirect does not require any approvals or whitelisting from Stoic. It is similar to single sign-on.
 
-# Update
-Small update #1
-Test1234
+## Local development
+
+Stoic Wallet is a [Create React App](https://create-react-app.dev/) project.
+
+### Prerequisites
+
+- **Node.js 16.** The current `react-scripts@4` toolchain does **not** build on Node ≥ 17
+  (`ERR_PACKAGE_PATH_NOT_EXPORTED`). Use [nvm](https://github.com/nvm-sh/nvm):
+  `nvm install 16 && nvm use 16`.
+- Installing dependencies currently requires a GitHub token with `read:packages` for the private
+  `@psychedelic` package, exported as `PAT` (see issue #55 for context / cleanup).
+
+### Install & run
+
+```bash
+npm install
+npm start            # dev server at http://localhost:3000
+```
+
+### Production build
+
+```bash
+npm run build        # outputs to ./build
+```
+
+> If the build/start scripts fail with an OpenSSL error, prefix them with
+> `NODE_OPTIONS=--openssl-legacy-provider`.
+
+### Notes
+
+- The wallet talks to IC **mainnet** (`icp0.io`) by default.
+- To integrate Stoic login into your own app, see
+  [stoic-identity](https://github.com/Toniq-Labs/stoic-identity).


### PR DESCRIPTION
Closes #22.

Adds a **Local development** section: Node 16 requirement, install/run/build steps, the OpenSSL-legacy note, and the `@psychedelic`/`PAT` caveat (cross-refs #55). Based on actually getting the app to build for the #54 preview.

_Opened by the agentops control plane._