### PR TITLE
chore(#55): declare supported Node via engines field

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,8 +65,10 @@
     ]
   },
   "devDependencies": {
-
     "redux": "^4.1.0",
     "webpack": "4.44.2"
+  },
+  "engines": {
+    "node": ">=16 <17"
   }
 }


### PR DESCRIPTION
Adds `"engines": { "node": ">=16 <17" }` to make the supported Node version explicit (matches `.nvmrc`; complements #55). npm only warns by default, so it is non-breaking.

Left open for your review/merge.