### PR TITLE
Fix cycle top-up (CMC notify_top_up) + update tx explorer links

### DIFF
--- a/src/components/Transactions.js
+++ b/src/components/Transactions.js
@@ -85,7 +85,7 @@ export default function Transactions(props) {
                             Fee
                             <br />(
                             <a
-                              href={'https://ic.house/ICP/tx/' + tx.hash}
+                              href={'https://dashboard.internetcomputer.org/transaction/' + tx.hash}
                               target="_blank"
                               rel="noreferrer"
                             >
@@ -102,7 +102,7 @@ export default function Transactions(props) {
                             from {tx.from}
                             <br />(
                             <a
-                              href={'https://ic.house/ICP/tx/' + tx.hash}
+                              href={'https://dashboard.internetcomputer.org/transaction/' + tx.hash}
                               target="_blank"
                               rel="noreferrer"
                             >

--- a/src/ic/candid/cycles.did.js
+++ b/src/ic/candid/cycles.did.js
@@ -28,7 +28,27 @@ export default ({ IDL }) => {
     'ToppedUp' : IDL.Null,
   });
   const Result = IDL.Variant({ 'Ok' : CyclesResponse, 'Err' : IDL.Text });
+  // New cmc_notify flow (replaces the deprecated ledger_notify / transaction_notification).
+  const NotifyTopUpArg = IDL.Record({
+    'block_index' : IDL.Nat64,
+    'canister_id' : IDL.Principal,
+  });
+  const NotifyError = IDL.Variant({
+    'Refunded' : IDL.Record({
+      'block_index' : IDL.Opt(IDL.Nat64),
+      'reason' : IDL.Text,
+    }),
+    'InvalidTransaction' : IDL.Text,
+    'Other' : IDL.Record({
+      'error_message' : IDL.Text,
+      'error_code' : IDL.Nat64,
+    }),
+    'Processing' : IDL.Null,
+    'TransactionTooOld' : IDL.Nat64,
+  });
+  const NotifyTopUpResult = IDL.Variant({ 'Ok' : IDL.Nat, 'Err' : NotifyError });
   return IDL.Service({
+    'notify_top_up' : IDL.Func([NotifyTopUpArg], [NotifyTopUpResult], []),
     'get_average_icp_xdr_conversion_rate' : IDL.Func(
         [],
         [IcpXdrConversionRateCertifiedResponse],

--- a/src/ic/extjs.js
+++ b/src/ic/extjs.js
@@ -481,15 +481,22 @@ class ExtConnection {
                 amount: {e8s: amount},
               };
               const block = await api.send_dfx(args);
-              args = {
-                block_height: block,
-                max_fee: {e8s: fee},
-                from_subaccount: [getSubAccountArray(from_sa ?? 0)],
-                to_subaccount: [getSubAccountArray(_to_sub)],
-                to_canister: Principal.fromText(CYCLES_MINTING_CANISTER_ID),
-              };
-              await api.notify_dfx(args);
-              return true; // Success
+              // New cmc_notify flow: notify the Cycles Minting Canister directly via
+              // notify_top_up, replacing the deprecated ledger notify_dfx ->
+              // transaction_notification push. See:
+              // https://forum.dfinity.org/t/deprecating-the-ledger-notify-flow-for-minting-cycles-in-favor-of-cmc-notify/42502
+              const cmc = this.canister(CYCLES_MINTING_CANISTER_ID, cyclesIDL);
+              const notifyRes = await cmc.notify_top_up({
+                block_index: BigInt(block),
+                canister_id: Principal.fromText(canister),
+              });
+              if (notifyRes.Err !== undefined) {
+                throw new Error(
+                  'Cycles top-up notification failed: ' +
+                    JSON.stringify(notifyRes.Err, (k, v) => (typeof v === 'bigint' ? v.toString() : v)),
+                );
+              }
+              return true; // notifyRes.Ok holds the cycles minted
             } catch (e) {
               throw e; // or handle error as appropriate
             }


### PR DESCRIPTION
Closes #53 and #21.\n\nMigrates cycle top-up from the deprecated ledger notify_dfx -> transaction_notification flow to the CMC notify_top_up (cmc_notify) flow (adds notify_top_up + NotifyError to cycles.did.js), and points the View Transaction links at dashboard.internetcomputer.org.\n\nNeeds a build (Node 16) + a small real mainnet top-up to verify before merge.