### PR TITLE
security: add rel="noopener noreferrer" to target=_blank links

### DIFF
--- a/src/components/NFTList.js
+++ b/src/components/NFTList.js
@@ -307,7 +307,7 @@ export default function NFTList(props) {
                             <IconButton
                               size="small"
                               href={'https://icscan.io/canister/' + nft.canister}
-                              target="_blank"
+                              target="_blank" rel="noopener noreferrer"
                               edge="end"
                               aria-label="search"
                             >

--- a/src/components/Neuron.js
+++ b/src/components/Neuron.js
@@ -129,7 +129,7 @@ export default function Neuron(props) {
           subheader={
             <Typography style={{fontSize: 14}} color={"primary"}>
               {"#"+props.neuron.id}
-              <IconButton href={"https://icscan.io/neuron/"+props.neuron.id} target="_blank" size="small" edge="end" aria-label="copy">
+              <IconButton href={"https://icscan.io/neuron/"+props.neuron.id} target="_blank" rel="noopener noreferrer" size="small" edge="end" aria-label="copy">
                 <LaunchIcon style={{ fontSize: 18 }} />
               </IconButton>
             </Typography>}

--- a/src/ic/collections.js
+++ b/src/ic/collections.js
@@ -11,7 +11,7 @@ export default [
       "c7e461041c0c5800a56b64bb7cefc247abc0bbbb99bd46ff71c64e92d9f5c2f9",
     blurb: (
       <>
-        <p style={{display:"none"}}><strong>The Cronic's Marketplace is offline during our Public Sale (starting 18.10 3PM UTC). Please head over to the <a href="https://cronic.toniqlabs.com/" target="_blank">Cronic Dashboard</a> if you would like to participate. The marketplace will be online as soon as the sales conclude. You can still delist your Cronics during this time</strong></p>
+        <p style={{display:"none"}}><strong>The Cronic's Marketplace is offline during our Public Sale (starting 18.10 3PM UTC). Please head over to the <a href="https://cronic.toniqlabs.com/" target="_blank" rel="noopener noreferrer">Cronic Dashboard</a> if you would like to participate. The marketplace will be online as soon as the sales conclude. You can still delist your Cronics during this time</strong></p>
         <a style={{display:"none"}} href="https://cronic.toniqlabs.com/" target="_blank"><img style={{maxWidth:800}} src="https://cronic.toniqlabs.com/banner.png" /></a>
         Cronics is a Play-to-earn NFT game being developed by ToniqLabs for the
         Internet Computer. Cronics incorporates breeding mechanics, wearable
@@ -320,7 +320,7 @@ export default [
     commission: 0.02,
     comaddress:
       "df13f7ef228d7213c452edc3e52854bc17dd4189dfc0468d8cb77403e52b5a69",
-    blurb: (<>ICmojis are playable characters in ICmoji Origins - a multiplayer strategy game built on the Internet Computer. Learn more at our <a href="https://icmoji.com/" target="_blank">website</a></>),
+    blurb: (<>ICmojis are playable characters in ICmoji Origins - a multiplayer strategy game built on the Internet Computer. Learn more at our <a href="https://icmoji.com/" target="_blank" rel="noopener noreferrer">website</a></>),
   },
   {
     canister: "owuqd-dyaaa-aaaah-qapxq-cai",

--- a/src/views/AccountDetail.js
+++ b/src/views/AccountDetail.js
@@ -361,7 +361,7 @@ function AccountDetail(props) {
                   <Tooltip title="View in explorer (ICScan)">
                     <IconButton
                       href={'https://icscan.io/account/' + account.address}
-                      target="_blank"
+                      target="_blank" rel="noopener noreferrer"
                       edge="end"
                       aria-label="search"
                     >

--- a/src/views/Settings.js
+++ b/src/views/Settings.js
@@ -150,7 +150,7 @@ function Settings(props) {
               </>
             } />
           <ListItemSecondaryAction>
-            <IconButton href={"https://icscan.io/principal/"+identity.principal} target="_blank" edge="end" aria-label="search">
+            <IconButton href={"https://icscan.io/principal/"+identity.principal} target="_blank" rel="noopener noreferrer" edge="end" aria-label="search">
               <LaunchIcon />
             </IconButton>
           </ListItemSecondaryAction>
@@ -205,7 +205,7 @@ function Settings(props) {
                 <IconButton onClick={() => clipboardCopy(principal.identity.principal)} edge="end">
                   <FileCopyIcon />
                 </IconButton>
-                <IconButton href={"https://icscan.io/principal/"+principal.identity.principal} target="_blank" edge="end" aria-label="search">
+                <IconButton href={"https://icscan.io/principal/"+principal.identity.principal} target="_blank" rel="noopener noreferrer" edge="end" aria-label="search">
                   <LaunchIcon />
                 </IconButton>
                 { principals.length > 1 ?


### PR DESCRIPTION
Closes #70.

Adds rel=noopener noreferrer to the 7 external target=_blank links that lacked it (reverse-tabnabbing hardening). Adjacency-checked so tags that already had rel on an adjacent line were left untouched (no duplicate attributes). Builds cleanly on Node 16.

(Netlify preview will pass once the build foundation #65 is merged to main.)