### PR TITLE
cleanup: remove debug console.log statements

### DIFF
--- a/src/components/AddTokenForm.js
+++ b/src/components/AddTokenForm.js
@@ -28,7 +28,7 @@ export default function AddTokenForm(props) {
       try{
         await props.onClick(canisterId, standard);
       } catch(e){
-        console.log(e);
+        console.error(e);
         props.alert("Error adding token", e.message);
       } finally {
         props.loader(false);

--- a/src/components/NFTList.js
+++ b/src/components/NFTList.js
@@ -135,7 +135,7 @@ export default function NFTList(props) {
       return props.alert('You were successful!', 'Your NFT has been wrapped!');
     } catch (e) {
       props.loader(false);
-      console.log(e);
+      console.error(e);
       return;
     }
   };

--- a/src/components/TopupForm.js
+++ b/src/components/TopupForm.js
@@ -35,7 +35,6 @@ export default function TopupForm(props) {
     props.error(e);
   };
   const review = () => {
-    console.log(amount, fee, amount + fee, Number(amount) + Number(fee));
     if (isNaN(amount)) return error('Please enter a valid amount to send');
     if (!validatePrincipal(to)) return error('Please enter a valid canister ID');
     if (Number(amount) + Number(fee) > balance) return error('You have insufficient ICP');

--- a/src/containers/Connect.js
+++ b/src/containers/Connect.js
@@ -17,7 +17,7 @@ function Connect(props) {
       dispatch({ type: 'createwallet', payload : {identity : identity}});
       props.login();
     }).catch(e => {
-      console.log(e);
+      console.error(e);
     }).finally(() => {
       setTimeout(() => {
         setOpen(true);
@@ -52,7 +52,7 @@ function Connect(props) {
           props.loader(false);
           setOpen(true)
         }).catch(e => {
-          console.log(e);
+          console.error(e);
         }).finally(() => {
           setOpen(true)
           props.loader(false)

--- a/src/containers/Unlock.js
+++ b/src/containers/Unlock.js
@@ -44,7 +44,7 @@ function Unlock(props) {
       StoicIdentity.unlock(identity, od).then(r => {
         props.login();
       }).catch(e => {
-        console.log(e);
+        console.error(e);
       }).finally(() => {
         setOpen(true)
       });

--- a/src/ic/identity.js
+++ b/src/ic/identity.js
@@ -261,7 +261,7 @@ const StoicIdentity = {
           const openlogin = await loadOpenLogin();
           await openlogin.logout();
         } catch (e) {
-          console.log(e);
+          console.error(e);
         }
       }
       delete identities[_id.principal];
@@ -289,7 +289,7 @@ const StoicIdentity = {
           const openlogin = await loadOpenLogin();
           await openlogin.logout();
         } catch (e) {
-          console.log(e);
+          console.error(e);
         }
       }
       delete identities[_id.principal];
@@ -316,7 +316,7 @@ const StoicIdentity = {
           const openlogin = await loadOpenLogin();
           await openlogin.logout();
         } catch (e) {
-          console.log(e);
+          console.error(e);
         }
       }
       //setup new

--- a/src/index.js
+++ b/src/index.js
@@ -232,7 +232,6 @@ const loadDbFast = () => {
     //db versioning
     if (!Array.isArray(db)) {
       db = [[db],[],[0,0,0]];
-      console.log("Converting old DB to new");
     }
     if (db.length === 2) {
       db[2] = [0,0,0];
@@ -299,7 +298,7 @@ if (params.get('stoicTunnel') !== null) {
                         requiresConfirmation = true;
                       }
                       if (requiresConfirmation) {
-                        console.log(e);
+                        console.error(e);
                         jspopup("Are you sure you want to sign this message from "+app.host+"?", "Sign", "Reject")
                           .then(async (result) => {
                             if (result) {
@@ -370,7 +369,6 @@ if (params.get('stoicTunnel') !== null) {
 
   
   if (params.get('transport') !== null && params.get('transport') == "popup" && params.get('lid') !== null) {
-    console.log("TESTING");
     window.onload= () => {
       window.opener.postMessage({
         action : "stoicPopupLoad",

--- a/src/store.js
+++ b/src/store.js
@@ -16,17 +16,14 @@ function initDb(_db){
     var savenow = false;
     if (!Array.isArray(db)) {
       db = [[db],[]];
-      console.log("Converting old DB to new");
       savenow = true;
     }
     if (db.length === 2) {
       db.push([0,0,0]);
-      console.log("Converting old DB to new");
       savenow = true;
     }
     if (db.length === 3) {
       db.push(DBVERSION);
-      console.log("Converting old DB to new");
       savenow = true;
     }
     let dbCurrentVersion = db[3];
@@ -194,7 +191,6 @@ function saveDb(newState){
 function rootReducer(state = initDb(), action) {
   switch(action.type){
     case "refresh":
-      console.log("Detected storage update");
       return initDb(action.payload);
     case "app/edit":
       return saveDb({

--- a/src/utils.js
+++ b/src/utils.js
@@ -15,7 +15,6 @@ function fallbackCopyTextToClipboard(text) {
   try {
     var successful = document.execCommand('copy');
     var msg = successful ? 'successful' : 'unsuccessful';
-    console.log('Fallback: Copying text command was ' + msg);
   } catch (err) {
     console.error('Fallback: Oops, unable to copy', err);
   }
@@ -40,7 +39,6 @@ clipboardCopy = (text) => {
     return;
   }
   navigator.clipboard.writeText(text).then(function() {
-    console.log('Async: Copying to clipboard was successful!');
   }, function(err) {
     console.error('Async: Could not copy text: ', err);
   });

--- a/src/views/AccountDetail.js
+++ b/src/views/AccountDetail.js
@@ -321,7 +321,7 @@ function AccountDetail(props) {
       if (!ignoreChange) dispatch({type: 'currentToken', payload: {index: account.tokens.length}});
       return true;
     } catch(e){
-      console.log(e);
+      console.error(e);
       throw new Error('There was a problem adding that token');
     }
   };


### PR DESCRIPTION
Closes #71.

- Removes 9 pure-debug logs (incl. console.log(amount, fee, ...) in TopupForm that logged transaction amounts, a stray "TESTING", and "Converting old DB to new"/"Detected storage update").
- Converts 10 catch-block console.log(e) to console.error(e) (keeps error visibility, correct method).

No functional change; builds cleanly on Node 16.