### PR TITLE
security: post auth responses to the requesting origin instead of *

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -190,9 +190,9 @@ const sendMessageToExtension = (e, success, data) => {
     if (e.data.endpoint === 'call') {
       response.complete = false;
     }
-    window.opener.postMessage(response, '*');
+    window.opener.postMessage(response, e.origin || '*');
   } else {
-    window.parent.postMessage(response, '*');
+    window.parent.postMessage(response, e.origin || '*');
   }
 }
 const verify = async (data, apikey, sig) => {

--- a/src/views/AccountDetail.js
+++ b/src/views/AccountDetail.js
@@ -131,7 +131,7 @@ function AccountDetail(props) {
                   : 'Standard',
               };
               if (app && app.apikey === e.data.apikey) {
-                window.opener.postMessage(authResponse, '*');
+                window.opener.postMessage(authResponse, e.origin || '*');
               } else {
                 props
                   .confirm(
@@ -156,9 +156,9 @@ function AccountDetail(props) {
                         app.apikey = e.data.apikey;
                         dispatch({type: 'app/edit', payload: {app: app}});
                       }
-                      window.opener.postMessage(authResponse, '*');
+                      window.opener.postMessage(authResponse, e.origin || '*');
                     } else {
-                      window.opener.postMessage({action: 'rejectAuthorization'}, '*');
+                      window.opener.postMessage({action: 'rejectAuthorization'}, e.origin || '*');
                     }
                   });
               }


### PR DESCRIPTION
Partially addresses #69 (outbound half).

The auth/delegation responses were posted with a wildcard target origin (*), so any window in the opener/parent chain could read them. These handlers already have the senders origin (e.origin), so this targets the response to that specific origin. The only remaining * is the pre-handshake initiateStoicConnect signal (no e available yet, carries no sensitive data).

Low risk (responses go to the same origin that made the request), builds clean. The inbound half of #69 (validating e.origin against the registered app host) is left for a follow-up that needs testing against real stoic-identity consumers, since stored app hosts may not all match origin format.