### PR TITLE
security: add baseline response security headers

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,4 @@
+/*
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
+  Permissions-Policy: camera=(), microphone=(), geolocation=()


### PR DESCRIPTION
Adds public/_headers (served by Netlify) with safe baseline hardening:\n- X-Content-Type-Options: nosniff\n- Referrer-Policy: strict-origin-when-cross-origin\n- Permissions-Policy: camera=(), microphone=(), geolocation=() (features the wallet doesnt use)\n\nDeliberately avoids X-Frame-Options/strict CSP since the wallet is framed by dapps (the stoic-identity iframe/popup flow) and connects to many IC canisters — those need separate, tested work.