### PR TITLE
feat: add a top-level ErrorBoundary

### DIFF
--- a/src/components/ErrorBoundary.js
+++ b/src/components/ErrorBoundary.js
@@ -1,0 +1,28 @@
+import React from 'react';
+
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {hasError: false};
+  }
+  static getDerivedStateFromError() {
+    return {hasError: true};
+  }
+  componentDidCatch(error, info) {
+    console.error('Uncaught error:', error, info);
+  }
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div style={{padding: 40, textAlign: 'center', fontFamily: 'Roboto, sans-serif'}}>
+          <h2>Something went wrong</h2>
+          <p>Please reload the page. If the problem persists, contact support@toniqlabs.com.</p>
+          <button onClick={() => window.location.reload()}>Reload</button>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import { ThemeProvider } from '@material-ui/core/styles';
 import App from './App';
+import ErrorBoundary from './components/ErrorBoundary';
 import { Provider } from 'react-redux'
 import store from './store'
 import {StoicIdentity} from './ic/identity.js';
@@ -383,7 +384,9 @@ if (params.get('stoicTunnel') !== null) {
     <Provider store={store}>
       <ThemeProvider theme={theme}>
         <CssBaseline />
-        <App />
+        <ErrorBoundary>
+          <App />
+        </ErrorBoundary>
       </ThemeProvider>
     </Provider>,
     document.querySelector('#root'),


### PR DESCRIPTION
Wraps the app in a React ErrorBoundary so an uncaught render error shows a friendly fallback (with a reload button + support contact) instead of a blank white screen. Logs the error via console.error. Builds cleanly on Node 16.