### PR TITLE
docs: add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,16 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in Stoic Wallet, please report it responsibly:
+
+- Email **support@toniqlabs.com**
+- Please do **not** open a public GitHub issue for security-sensitive reports.
+
+We aim to acknowledge reports within a few business days.
+
+## Scope
+
+Stoic Wallet is a non-custodial frontend wallet for the Internet Computer. Reports involving
+key handling, the app-authorization / delegation (`stoic-identity`) flow, transaction signing,
+and dependency vulnerabilities are especially valued.


### PR DESCRIPTION
Adds a responsible-disclosure security policy so vulnerability reports go to support@toniqlabs.com privately rather than public issues.