### PR TITLE
test: add first unit test (formatNumberForDisplay)

### DIFF
--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -1,0 +1,12 @@
+import {formatNumberForDisplay} from './utils';
+
+describe('formatNumberForDisplay', () => {
+  it('returns regular numbers unchanged', () => {
+    expect(formatNumberForDisplay(123)).toBe(123);
+    expect(formatNumberForDisplay(1.5)).toBe(1.5);
+    expect(formatNumberForDisplay(0)).toBe(0);
+  });
+  it('expands small scientific-notation numbers to fixed decimals', () => {
+    expect(formatNumberForDisplay(1e-7)).toBe('0.0000001');
+  });
+});


### PR DESCRIPTION
The repo had no tests. Adds a unit test for formatNumberForDisplay (a pure util) via the existing react-scripts/jest runner — a foothold for adding coverage, especially before the #55 modernization. Run with npm test.