### PR TITLE
security: ignore inbound messages from opaque/null origins

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -279,6 +279,8 @@ const loadDbFast = () => {
 if (params.get('stoicTunnel') !== null) {
   window.addEventListener("message", async function(e){
     if (e && e.data && (e.data.target === 'STOIC-IFRAME' || e.data.target === 'STOIC-POPUP')) {
+      // #69: ignore messages from opaque/empty origins (sandboxed/data: frames)
+      if (!e.origin || e.origin === 'null') return;
       const state = loadDbFast();
       if (!state) {
         sendMessageToExtension(e, false, "There was an error - please ensure you have Cookies Enabled (known issue for Brave users)");


### PR DESCRIPTION
Partial inbound hardening for #69: the message handler now ignores postMessages whose e.origin is empty or 'null' (sandboxed/data: frames), which have no legitimate reason to drive the wallet. Real https dapp origins are unaffected. (Full origin↔app.host matching remains a tested follow-up.)