### PR TITLE
test: add unit tests for compressAddress and numf

### DIFF
--- a/src/utils.helpers.test.js
+++ b/src/utils.helpers.test.js
@@ -1,0 +1,27 @@
+import {compressAddress, numf} from './utils';
+
+describe('compressAddress', () => {
+  it('returns empty string for falsy input', () => {
+    expect(compressAddress('')).toBe('');
+    expect(compressAddress(undefined)).toBe('');
+  });
+  it('shortens a 64-char hex account id', () => {
+    const id = 'a'.repeat(64);
+    expect(compressAddress(id)).toBe(id.slice(0, 16) + '...');
+  });
+  it('leaves short principals unchanged', () => {
+    expect(compressAddress('aaaaa-aa')).toBe('aaaaa-aa');
+  });
+});
+
+describe('numf', () => {
+  it('passes through N/A', () => {
+    expect(numf('N/A')).toBe('N/A');
+  });
+  it('formats with thousands separators and 2 decimals by default', () => {
+    expect(numf(1234.5)).toBe('1,234.50');
+  });
+  it('respects the decimals argument', () => {
+    expect(numf(1.23456, 4)).toBe('1.2346');
+  });
+});


### PR DESCRIPTION
Expands coverage with unit tests for two more pure utils (compressAddress, numf), covering the hex-account, short-principal, N/A, default-decimals, and custom-decimals cases. Verified passing via npm test.