### PR TITLE
chore: add .prettierrc

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all",
+  "printWidth": 100,
+  "bracketSpacing": false,
+  "arrowParens": "avoid"
+}


### PR DESCRIPTION
Adds a Prettier config matching the codebase's existing conventions (single quotes, trailing commas, no bracket spacing, avoid arrow parens) so formatting is consistent and reviewable. Pairs with the .editorconfig PR.