### PR TITLE
perf(build): remove duplicate prebuild script

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "prebuild": "react-scripts build",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {


### PR DESCRIPTION
package.json had `"prebuild": "react-scripts build"`, and npm runs `prebuild` automatically before `build` — so `npm run build` compiled the app **twice**, doubling CI/Netlify build time. Removes the redundant prebuild script. Build output unchanged.