### PR TITLE
chore: add .gitattributes (normalize line endings)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+* text=auto eol=lf
+*.png binary
+*.ico binary
+*.jpg binary


### PR DESCRIPTION
Normalizes line endings to LF (text=auto eol=lf) and marks binary assets, preventing CRLF/LF churn across contributors. Pairs with .editorconfig.