### PR TITLE
fix: replace deprecated Buffer() constructor with Buffer.from()

### DIFF
--- a/src/ic/extjs.js
+++ b/src/ic/extjs.js
@@ -43,7 +43,7 @@ const constructUser = u => {
   }
 };
 const tokenIdentifier = (principal, index) => {
-  const padding = Buffer('\x0Atid');
+  const padding = Buffer.from('\x0Atid');
   const array = new Uint8Array([
     ...padding,
     ...Principal.fromText(principal).toUint8Array(),
@@ -54,7 +54,7 @@ const tokenIdentifier = (principal, index) => {
 const decodeTokenId = tid => {
   var p = [...Principal.fromText(tid).toUint8Array()];
   var padding = p.splice(0, 4);
-  if (toHexString(padding) !== toHexString(Buffer('\x0Atid'))) {
+  if (toHexString(padding) !== toHexString(Buffer.from('\x0Atid'))) {
     return {
       index: 0,
       canister: tid,

--- a/src/ic/neuron.js
+++ b/src/ic/neuron.js
@@ -33,7 +33,7 @@ const sha256 = data => {
   return Buffer.from(new Uint8Array(shaObj.array()));
 };
 const getStakingAddress = (principal, nonce) => {
-  if (typeof nonce == 'string') nonce = Buffer(nonce);
+  if (typeof nonce == 'string') nonce = Buffer.from(nonce);
   if (nonce.length > 8) return false;
   const array = new Uint8Array([
     [0x0c],

--- a/src/ic/utils.js
+++ b/src/ic/utils.js
@@ -29,7 +29,7 @@ const amountToBigInt = (amount, decimals) => {
   return amount;
 }
 const principalToAccountIdentifier = (p, s) => {
-  const padding = Buffer("\x0Aaccount-id");
+  const padding = Buffer.from("\x0Aaccount-id");
   const array = new Uint8Array([
       ...padding,
       ...Principal.fromText(p).toUint8Array(),


### PR DESCRIPTION
The deprecated/unsafe `Buffer(arg)` constructor was used in 4 spots (extjs.js, utils.js, neuron.js). Switches to `Buffer.from(arg)` (the safe, non-deprecated API). Behaviour is identical for these string/array inputs. Builds clean.