### PR TITLE
chore: add repository + bugs metadata to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,5 +70,12 @@
   },
   "engines": {
     "node": ">=16 <17"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Toniq-Labs/stoic-wallet.git"
+  },
+  "bugs": {
+    "url": "https://github.com/Toniq-Labs/stoic-wallet/issues"
   }
 }


### PR DESCRIPTION
Adds `repository` and `bugs` fields so tooling and npm/GitHub link back to the repo + issue tracker. (Intentionally omits `homepage` since CRA uses it for asset base paths, which would break Netlify deploy previews.)