### PR TITLE
chore: add Dependabot config (weekly npm updates)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"


### PR DESCRIPTION
Adds .github/dependabot.yml so dependency/security updates come in as automated weekly PRs (capped at 5). Helps chip away at the dependency debt tracked in #55.