### PR TITLE
security: autoComplete=off on password/seed inputs

### DIFF
--- a/src/components/WalletDialog.js
+++ b/src/components/WalletDialog.js
@@ -343,7 +343,7 @@ export default function WalletDialog(props) {
               label="Enter Password"
               fullWidth
               required
-              type="password"
+              type="password" autoComplete="off"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               style={{marginBottom: 20}}
@@ -353,7 +353,7 @@ export default function WalletDialog(props) {
               label="Confirm Password"
               fullWidth
               required
-              type="password"
+              type="password" autoComplete="off"
               value={password2}
               onChange={(e) => setPassword2(e.target.value)}
             />

--- a/src/containers/Unlock.js
+++ b/src/containers/Unlock.js
@@ -191,7 +191,7 @@ function Unlock(props) {
                 label="Enter Password"
                 fullWidth
                 required
-                type="password"
+                type="password" autoComplete="off"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
               />


### PR DESCRIPTION
Adds autoComplete=off to the 3 password inputs (unlock + wallet import/create dialogs) so browsers don't store/autofill the wallet password or seed phrase. Builds clean.