### PR TITLE
a11y: announce loading overlay to screen readers

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -144,7 +144,7 @@ export default function App() {
       ) : (
         ''
       )}
-      <Backdrop className={classes.backdrop} open={loaderOpen}>
+      <Backdrop className={classes.backdrop} open={loaderOpen} role="status" aria-live="polite">
         <CircularProgress color="inherit" />
         <h2 style={{position: 'absolute', marginTop: '120px'}}>{loaderText ?? 'Loading...'}</h2>
       </Backdrop>


### PR DESCRIPTION
Adds role=status + aria-live=polite to the loading Backdrop so screen-reader users hear the 'Loading...' state. Builds clean.