### PR TITLE
test: add unit tests for ErrorBoundary

### DIFF
--- a/src/components/ErrorBoundary.test.js
+++ b/src/components/ErrorBoundary.test.js
@@ -1,0 +1,11 @@
+import ErrorBoundary from './ErrorBoundary';
+
+describe('ErrorBoundary', () => {
+  it('flags hasError from getDerivedStateFromError', () => {
+    expect(ErrorBoundary.getDerivedStateFromError(new Error('boom'))).toEqual({hasError: true});
+  });
+  it('initializes without an error state', () => {
+    const eb = new ErrorBoundary({});
+    expect(eb.state).toEqual({hasError: false});
+  });
+});


### PR DESCRIPTION
Adds unit tests for the ErrorBoundary component (getDerivedStateFromError + initial state). Verified passing via npm test.