### PR TITLE
perf: memoize NFT/token card components

### DIFF
--- a/src/components/NFTCard.js
+++ b/src/components/NFTCard.js
@@ -24,7 +24,7 @@ const styles = {
     marginBottom: 12,
   },
 };
-export default function NFTCard(props) {
+function NFTCard(props) {
   const handleClick = () => {
     props.onClick();
   };
@@ -48,3 +48,5 @@ export default function NFTCard(props) {
     </Grid>
   );
 }
+
+export default React.memo(NFTCard);

--- a/src/components/NftThumbnail.js
+++ b/src/components/NftThumbnail.js
@@ -2,7 +2,7 @@ import React from "react";
 
 import { compressAddress } from "../utils.js";
 
-export default function NftThumbnail({ nft }) {
+function NftThumbnail({ nft }) {
   let link = getNftLink(nft);
   let img = getNftImg(nft);
   if (link) {
@@ -89,3 +89,5 @@ const getNftImg = (nft) => {
     );
   else return false;
 };
+
+export default React.memo(NftThumbnail);

--- a/src/components/TokenCard.js
+++ b/src/components/TokenCard.js
@@ -28,7 +28,7 @@ const styles = {
 };
 var intervalId = 0;
 const api = extjs.connect('https://icp0.io/');
-export default function TokenCard(props) {
+function TokenCard(props) {
   const [balance, setBalance] = React.useState(false);
   const currentPrincipal = useSelector(state => state.currentPrincipal);
   const identity = useSelector(state =>
@@ -82,3 +82,5 @@ export default function TokenCard(props) {
     </Grid>
   );
 }
+
+export default React.memo(TokenCard);


### PR DESCRIPTION
Wraps the presentational NFTCard, TokenCard and NftThumbnail components in React.memo so they don't re-render when their props are unchanged — meaningful in the NFT/token grids which render many instances. Builds clean.