### PR TITLE
perf+privacy: lazy-load images, no-referrer on thumbnails

### DIFF
--- a/src/components/Blockie.js
+++ b/src/components/Blockie.js
@@ -5,6 +5,6 @@ const style = {
   height:"100%", 
 }
 function Blockie(props) {
-  return (<img alt={props.address} style={style} src={makeBlockie(props.address)}/>);
+  return (<img alt={props.address} loading="lazy" decoding="async" style={style} src={makeBlockie(props.address)}/>);
 }
 export default Blockie;

--- a/src/components/NftThumbnail.js
+++ b/src/components/NftThumbnail.js
@@ -7,12 +7,12 @@ export default function NftThumbnail({ nft }) {
   let img = getNftImg(nft);
   if (link) {
     return (<a href={link} target="_blank" rel="noreferrer" style={{ display: "block" }} >
-        {img ? (<img id={"img-"+nft.tokenid} alt={compressAddress(nft.tokenid)} src={img} style={{width:64}} />) : (<p>No preview available</p>)}
+        {img ? (<img id={"img-"+nft.tokenid} alt={compressAddress(nft.tokenid)} src={img} loading="lazy" decoding="async" referrerPolicy="no-referrer" style={{width:64}} />) : (<p>No preview available</p>)}
       </a>
     );
   } else {
     if (img) {
-      return (<img id={"img-"+nft.tokenid} alt={compressAddress(nft.tokenid)} src={img} style={{width:64}} />);
+      return (<img id={"img-"+nft.tokenid} alt={compressAddress(nft.tokenid)} src={img} loading="lazy" decoding="async" referrerPolicy="no-referrer" style={{width:64}} />);
     } else {
       return (<p>No preview available</p>);
     }


### PR DESCRIPTION
Adds loading=lazy + decoding=async to NFT thumbnails and blockie avatars (they render in long grids → defers off-screen image loads), and referrerPolicy=no-referrer on the external NFT-canister thumbnails so those canisters don't receive the referrer. Builds clean.