### PR TITLE
fix: correct user-facing typos

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -359,7 +359,7 @@ if (params.get('stoicTunnel') !== null) {
                   sendMessageToExtension(e, false, "Invalid signature for payload");
                 }
               } else {        
-                sendMessageToExtension(e, false, "The principal is not unlocked, please go to StoicWallet and unlocl your wallet");
+                sendMessageToExtension(e, false, "The principal is not unlocked, please go to StoicWallet and unlock your wallet");
               }
             }).catch(err => {            
               sendMessageToExtension(e, false, err);

--- a/src/views/AccountDetail.js
+++ b/src/views/AccountDetail.js
@@ -138,7 +138,7 @@ function AccountDetail(props) {
                     'Authorize Application',
                     'Do you want to authorize "' +
                       e.origin +
-                      '" to access your princpal "' +
+                      '" to access your principal "' +
                       principal +
                       '"?',
                     'Reject',


### PR DESCRIPTION
Fixes two typos shown to users: 'unlocl your wallet' -> 'unlock your wallet' (index.js error) and 'access your princpal' -> 'access your principal' (authorization prompt).