### PR TITLE
fix: disable autocorrect on the seed-phrase input

### DIFF
--- a/src/components/WalletDialog.js
+++ b/src/components/WalletDialog.js
@@ -297,6 +297,7 @@ export default function WalletDialog(props) {
               value={mnemonic}
               rows={2}
               onChange={(e) => setMnemonic(e.target.value)}
+              inputProps={{spellCheck: false, autoCapitalize: 'none', autoCorrect: 'off'}}
             />
           </DialogContent>
           <DialogActions>


### PR DESCRIPTION
Mobile/desktop browsers autocapitalize/autocorrect/spellcheck the mnemonic field, which can silently corrupt a seed phrase on entry. Sets spellCheck=false, autoCapitalize=none, autoCorrect=off on the Confirm Mnemonic Seed input. Builds clean.