### PR TITLE
fix: disable autocorrect on the recipient address input

### DIFF
--- a/src/components/SendForm.js
+++ b/src/components/SendForm.js
@@ -179,6 +179,7 @@ export default function SendForm(props) {
                 renderInput={params => (
                   <TextField
                     {...params}
+                    inputProps={{...params.inputProps, spellCheck: false, autoCapitalize: 'none', autoCorrect: 'off'}}
                     autoFocus
                     margin="dense"
                     label="Address of the Recipient"


### PR DESCRIPTION
Disables spellCheck/autoCapitalize/autoCorrect on the 'Address of the Recipient' field (merged with the Autocomplete's input props) so browsers don't mangle a pasted/typed ICP address or principal. Builds clean.