### PR TITLE
chore: remove unused web-vitals dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,8 +39,7 @@
         "react-timestamp": "^5.1.0",
         "sjcl": "^1.0.9",
         "starkbank-ecdsa": "^1.1.2",
-        "use-file-picker": "^1.3.0",
-        "web-vitals": "^1.0.1"
+        "use-file-picker": "^1.3.0"
       },
       "devDependencies": {
         "redux": "^4.1.0",
@@ -18486,11 +18485,6 @@
         "minimalistic-assert": "^1.0.0"
       }
     },
-    "node_modules/web-vitals": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-1.1.2.tgz",
-      "integrity": "sha512-PFMKIY+bRSXlMxVAQ+m2aw9c/ioUYfDgrYot0YUa+/xa0sakubWhSDyxAKwzymvXVdF4CZI71g06W+mqhzu6ig=="
-    },
     "node_modules/webidl-conversions": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
@@ -33854,11 +33848,6 @@
       "requires": {
         "minimalistic-assert": "^1.0.0"
       }
-    },
-    "web-vitals": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-1.1.2.tgz",
-      "integrity": "sha512-PFMKIY+bRSXlMxVAQ+m2aw9c/ioUYfDgrYot0YUa+/xa0sakubWhSDyxAKwzymvXVdF4CZI71g06W+mqhzu6ig=="
     },
     "webidl-conversions": {
       "version": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@dfinity/agent": "0.9.3",
     "@dfinity/auth-client": "0.9.3",
     "@dfinity/authentication": "0.9.3",
+    "@dfinity/candid": "0.9.3",
     "@dfinity/identity": "0.9.3",
     "@dfinity/principal": "0.9.3",
     "@fontsource/roboto": "^4.4.5",
@@ -22,6 +23,8 @@
     "dotenv": "^16.0.1",
     "ethereum-blockies-base64": "^1.0.2",
     "json-bigint": "^1.0.0",
+    "patch-package": "^6.4.7",
+    "postinstall-postinstall": "^2.1.0",
     "query-string": "^4.3.4",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
@@ -31,11 +34,7 @@
     "react-timestamp": "^5.1.0",
     "sjcl": "^1.0.9",
     "starkbank-ecdsa": "^1.1.2",
-    "use-file-picker": "^1.3.0",
-    "patch-package": "^6.4.7",
-    "postinstall-postinstall": "^2.1.0",
-    "web-vitals": "^1.0.1",
-    "@dfinity/candid": "0.9.3"
+    "use-file-picker": "^1.3.0"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
web-vitals isn't imported anywhere in src/ (the CRA reportWebVitals wiring isn't present), so it's dead weight. Removes it from dependencies. Builds clean. (Replaces Dependabot #102, which bumped an unused dep.)