### PR TITLE
chore: tidy Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,16 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
+    groups:
+      # Batch low-risk updates into one PR to cut review noise
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      # @dfinity/* must be upgraded together (coordinated + tested) — see #55, not piecemeal majors
+      - dependency-name: "@dfinity/*"
+        update-types: ["version-update:semver-major"]
+      # react-scripts / CRA toolchain majors are handled by the Node 20 migration (#107 / #55)
+      - dependency-name: "react-scripts"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
Reduces Dependabot noise and avoids the unmergeable bumps we just hit:\n- Groups minor + patch updates into a single weekly PR.\n- Ignores **major** bumps of `@dfinity/*` (must be upgraded together — see #55; this is what made #98 unmergeable).\n- Ignores major `react-scripts` bumps (handled by the Node 20 migration #107).