### PR TITLE
test: add a headless smoke check for build-system regressions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,3 +24,15 @@ npm run build      # production build -> ./build
 ## Reporting issues
 
 Use the issue templates. For **security** reports, see [SECURITY.md](SECURITY.md) — please don't open a public issue.
+
+## Smoke test
+
+A headless smoke test boots the built app in a browser and fails on runtime errors
+(e.g. a missing webpack polyfill) — the kind a plain `npm run build` can't catch:
+
+```bash
+npm install --no-save puppeteer   # one-time, pulls Chromium
+npm run build && npm run smoke
+```
+
+Network errors (no IC mainnet in CI) are ignored; it only fails on fatal JS errors or a blank app.

--- a/ci/smoke.yml
+++ b/ci/smoke.yml
@@ -1,0 +1,21 @@
+# Headless smoke check — move this to .github/workflows/smoke.yml to enable.
+# (Adding it under .github/workflows/ requires a token/permission that can write workflow files.)
+name: smoke
+on:
+  pull_request:
+  push:
+    branches: [main]
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+      - run: npm install
+      - run: npm install --no-save puppeteer
+      - run: npm run build
+        env:
+          CI: 'false'
+      - run: npm run smoke

--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "start": "craco start",
     "build": "craco build",
     "test": "craco test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "smoke": "node scripts/smoke-test.cjs"
   },
   "eslintConfig": {
     "extends": [

--- a/scripts/smoke-test.cjs
+++ b/scripts/smoke-test.cjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+/*
+ * Headless smoke test — catches runtime breakage a plain build can't.
+ * Serves ./build, loads it in headless Chromium, and FAILS if the app doesn't
+ * render or throws a fatal JS error (e.g. a missing webpack polyfill like
+ * `process is not defined`). Network errors (no mainnet in CI) are ignored.
+ *
+ *   npm run build && npm run smoke
+ */
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(process.cwd(), 'build');
+const PORT = Number(process.env.SMOKE_PORT || 8099);
+const MT = {'.html':'text/html','.js':'text/javascript','.css':'text/css','.json':'application/json',
+  '.png':'image/png','.jpg':'image/jpeg','.svg':'image/svg+xml','.ico':'image/x-icon',
+  '.woff':'font/woff','.woff2':'font/woff2','.ttf':'font/ttf','.map':'application/json','.wasm':'application/wasm'};
+const IGNORE = /ERR_NAME_NOT_RESOLVED|ERR_INTERNET_DISCONNECTED|ERR_CONNECTION|ERR_ADDRESS|net::|Failed to load resource/i;
+
+function serve() {
+  return http.createServer((q, s) => {
+    let p = path.normalize(path.join(ROOT, decodeURIComponent(q.url.split('?')[0])));
+    if (!p.startsWith(ROOT)) p = path.join(ROOT, 'index.html');
+    fs.stat(p, (e, st) => {
+      const f = !e && st.isFile() ? p : path.join(ROOT, 'index.html');
+      s.setHeader('Content-Type', MT[path.extname(f)] || 'application/octet-stream');
+      fs.createReadStream(f).pipe(s);
+    });
+  });
+}
+
+(async () => {
+  if (!fs.existsSync(path.join(ROOT, 'index.html'))) {
+    console.error('smoke: no build/ found — run `npm run build` first');
+    process.exit(2);
+  }
+  let puppeteer;
+  try { puppeteer = require('puppeteer'); }
+  catch { console.error('smoke: puppeteer not installed (npm i -D puppeteer)'); process.exit(2); }
+
+  const server = serve();
+  await new Promise((r) => server.listen(PORT, r));
+  const fatal = [];
+  const browser = await puppeteer.launch({
+    headless: 'new',
+    args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage'],
+  });
+  const page = await browser.newPage();
+  page.on('pageerror', (e) => fatal.push('Uncaught: ' + e.message.split('\n')[0]));
+  page.on('console', (m) => {
+    if (m.type() === 'error' && !IGNORE.test(m.text())) fatal.push('console.error: ' + m.text().slice(0, 200));
+  });
+  try { await page.goto(`http://127.0.0.1:${PORT}/`, { waitUntil: 'networkidle2', timeout: 30000 }); }
+  catch (e) { fatal.push('navigation: ' + e.message); }
+  await new Promise((r) => setTimeout(r, 2500));
+  const rootLen = await page.evaluate(() => (document.getElementById('root') || {}).innerHTML?.length || 0);
+  await browser.close();
+  server.close();
+
+  console.log(`smoke: #root rendered ${rootLen} chars, ${fatal.length} fatal error(s)`);
+  if (rootLen < 20) fatal.push('app did not render (#root is empty)');
+  if (fatal.length) {
+    console.error('SMOKE TEST FAILED:');
+    fatal.forEach((e) => console.error('  - ' + e));
+    process.exit(1);
+  }
+  console.log('✓ smoke test passed');
+})().catch((e) => { console.error('smoke: harness error:', e.message); process.exit(2); });


### PR DESCRIPTION
Adds a headless smoke test so build-tooling changes (like the Node 20 / webpack-5 migration) get a **runtime** check, not just a build check — exactly what would have caught the `process is not defined` crash in #107.

**What it does** (`scripts/smoke-test.cjs`, run via `npm run smoke`): serves `build/`, loads it in headless Chromium, and **fails** if the app doesn't render or throws a fatal JS error. Network errors (no IC mainnet in CI) are ignored.

**Usage:** `npm install --no-save puppeteer && npm run build && npm run smoke`. Puppeteer is intentionally **not** added as a dependency (keeps it off the Netlify install / deploy); CI installs it on demand.

**CI:** `ci/smoke.yml` is the GitHub Actions workflow — move it to `.github/workflows/smoke.yml` to enable (the token I have can't write workflow files directly). It builds + smoke-tests every PR on the Node version in `.nvmrc`.

Verified the script both **passes** on a good build and **catches** the `process is not defined` failure, using Chromium-in-Docker.