### PR TITLE
ci(dependabot): stop bumping coupled @dfinity / react stacks out of sync

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,9 +14,20 @@ updates:
           - "minor"
           - "patch"
     ignore:
-      # @dfinity/* must be upgraded together (coordinated + tested) — see #55, not piecemeal majors
+      # The @dfinity/* agent stack is tightly coupled and pinned at 0.9.x.
+      # These are 0.x packages, so a 0.9 -> 0.14 bump is a *minor* in semver terms
+      # but still breaking — it must be upgraded as a coordinated, tested whole
+      # (see #55/#128). Allow only patch updates here; do majors/minors by hand.
       - dependency-name: "@dfinity/*"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+      # react + react-dom must move together as a deliberate framework upgrade,
+      # never as a lone dependabot bump (see #126, react-dom 17 -> 19 mismatch).
+      - dependency-name: "react"
         update-types: ["version-update:semver-major"]
-      # react-scripts / CRA toolchain majors are handled by the Node 20 migration (#107 / #55)
+      - dependency-name: "react-dom"
+        update-types: ["version-update:semver-major"]
+      # react-scripts / CRA toolchain majors are handled by the migration (#107).
       - dependency-name: "react-scripts"
         update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Why
Dependabot keeps opening build-breaking PRs for packages that can only move as coordinated, tested upgrades:

- **#128** (the grouped minor/patch PR) fails because it includes `@dfinity/authentication` `0.9.3 -> 0.14.2`. The config already ignores `@dfinity/*` **majors**, but these are `0.x` packages, so `0.9 -> 0.14` is a **minor** in semver terms and slipped through into the group, dragging the whole `@dfinity` stack out of sync.
- **#126** (`react-dom` `17 -> 19`) fails because it bumps `react-dom` without `react` — they must move together.

## Change
- Ignore `@dfinity/*` **minor and major** updates (patch still allowed for security fixes within `0.9.x`). The stack gets upgraded deliberately as a whole.
- Ignore `react` / `react-dom` **majors** (framework upgrade, not a dep bump).

## Effect
The grouped minor/patch PR (#128) stops being poisoned by `@dfinity` and its 5 harmless updates (`@material-ui/icons`, `bigint-conversion`, `bip39`, `starkbank-ecdsa`, `crypto-browserify`) become mergeable. #126 stops recurring. No application code changes.