### PR TITLE
fix: correct NFTList action args and validate the mint result

### DIFF
--- a/src/components/NFTList.js
+++ b/src/components/NFTList.js
@@ -128,8 +128,8 @@ export default function NFTList(props) {
         );
       if (!r2) return error('There was an error wrapping this NFT!');
       props.loader(true, 'Wrapping NFT...');
-      await extjs.connect('https://icp0.io/', id).canister(wrappedCanister).mint(tokenid);
-      if (!r) return error('There was an error wrapping this NFT!');
+      var r3 = await extjs.connect('https://icp0.io/', id).canister(wrappedCanister).mint(tokenid);
+      if (!r3) return error('There was an error wrapping this NFT!');
       await props.loadNfts();
       props.loader(false);
       return props.alert('You were successful!', 'Your NFT has been wrapped!');
@@ -395,7 +395,7 @@ export default function NFTList(props) {
                                         key={1}
                                         onClick={() => {
                                           handleClose();
-                                          nftAction(nft.tokenid, nft.standard, 0);
+                                          nftAction(nft.tokenid, '00', nft.standard);
                                         }}
                                       >
                                         Remove Wearables


### PR DESCRIPTION
Two real defects in `src/components/NFTList.js`:

1. **Wrong argument order** — the "Remove Wearables" menu item calls `nftAction(nft.tokenid, nft.standard, 0)`, but the signature is `(tokenid, memo, standard)`. So `standard` became `0`, and `standard.toLowerCase()` threw `TypeError: (0).toLowerCase is not a function` every time the action ran. Fixed to `nftAction(nft.tokenid, '00', nft.standard)`.
2. **Unvalidated mint result** — after `await ...mint(tokenid)` the code re-checked `if (!r)`, where `r` was the *wrap* result asserted truthy earlier — so the mint step was never validated (dead check). Now captures `r3` from `mint()` and checks it.

Verified: full build + headless smoke test pass.