### PR TITLE
fix: route neuron dialogs through the app alert, not window.alert

### DIFF
--- a/src/views/Neurons.js
+++ b/src/views/Neurons.js
@@ -116,12 +116,12 @@ function Neurons(props) {
               alignItems="flex-start"
             >
             {neurons.map(n => {
-            return (<Neuron alert={alert} showNeuronTopupForm={showNeuronTopupForm} showNeuronDelayForm={showNeuronDelayForm} loader={props.loader} error={error} key={n.id} neuron={n} />)})}
+            return (<Neuron alert={props.alert} showNeuronTopupForm={showNeuronTopupForm} showNeuronDelayForm={showNeuronDelayForm} loader={props.loader} error={error} key={n.id} neuron={n} />)})}
             </Grid>
           </div>
         </>
       }
-        <NeuronForm alert={alert} loader={props.loader} error={error}>
+        <NeuronForm alert={props.alert} loader={props.loader} error={error}>
           <MainFab color="primary" aria-label="send"><AddIcon /></MainFab>
         </NeuronForm> 
         


### PR DESCRIPTION
In `src/views/Neurons.js`, `<Neuron>` and `<NeuronForm>` are passed `alert={alert}`, but the component defines no local `alert` — so it resolved to the global **`window.alert`**. Neuron success/error messages rendered as a native blocking browser popup instead of the app's MUI dialog, and the `alert(title, message)` two-arg contract broke.

Changed both to `alert={props.alert}` (the real handler, used everywhere else in the file).

Verified: full build + headless smoke test pass.