### PR TITLE
fix: validate recipient address before NFT transfer

### DIFF
--- a/src/components/SendNFTForm.js
+++ b/src/components/SendNFTForm.js
@@ -1,5 +1,6 @@
 /* global BigInt */
 import React from 'react';
+import {validateAddress, validatePrincipal} from '../ic/utils.js';
 import Button from '@material-ui/core/Button';
 import TextField from '@material-ui/core/TextField';
 import Dialog from '@material-ui/core/Dialog';
@@ -34,6 +35,8 @@ export default function SendNFTForm(props) {
     props.error(e);
   };
   const review = () => {
+    if (!validateAddress(to) && !validatePrincipal(to))
+      return error('Please enter a valid address to send to');
     setStep(1);
   };
   const submit = async () => {


### PR DESCRIPTION
`SendNFTForm.review()` only did `setStep(1)` — no validation — so a user could advance to the confirm screen and transfer an NFT to an **empty or malformed address**. NFT transfers are irreversible.

Added the same guard `SendForm` uses (`validateAddress` / `validatePrincipal`) before advancing, plus the import from `../ic/utils.js`.

Verified: full build + headless smoke test pass.