### PR TITLE
fix: reject non-positive send amounts and drop invalid <p href>

### DIFF
--- a/src/components/SendForm.js
+++ b/src/components/SendForm.js
@@ -48,6 +48,7 @@ export default function SendForm(props) {
   };
   const review = () => {
     if (isNaN(amount)) return error('Please enter a valid amount to send');
+    if (Number(amount) <= 0) return error('Please enter an amount greater than 0');
     if (isNaN(fee)) return error('Please enter a valid fee to use');
     if (fee !== minFee) return error('The fee must be ' + minFee);
     switch (props.data.symbol) {
@@ -234,7 +235,6 @@ export default function SendForm(props) {
                 </p>
               ) : (
                 <p
-                  href="#"
                   style={{cursor: 'pointer', fontWeight: 'bold'}}
                   onClick={() => setAdvanced(true)}
                 >


### PR DESCRIPTION
In `src/components/SendForm.js`:

1. **Amount guard** — `review()` only checked `isNaN(amount)`, which passes for `''`, `0`, and negatives (`isNaN(0) === false`). Added `if (Number(amount) <= 0) return error('Please enter an amount greater than 0')` so a zero/negative transfer can't reach the confirm step.
2. **Cleanup** — the "Show Advanced Options" element was `<p href="#">`; `href` is not valid on `<p>` (React drops it) and the click is already handled by `onClick`. Removed it so it matches the "Hide" branch.

Verified: full build + headless smoke test pass.