### PR TITLE
fix: surface auth/link errors instead of swallowing them

### DIFF
--- a/src/containers/Unlock.js
+++ b/src/containers/Unlock.js
@@ -94,6 +94,7 @@ function Unlock(props) {
     StoicIdentity.unlock(identity).then(r => {
       props.login();
     }).catch(e => {
+      error(e.message || String(e));
     }).finally(() => {
       setTimeout(() => {
         setOpen(true)

--- a/src/views/Settings.js
+++ b/src/views/Settings.js
@@ -45,6 +45,7 @@ function Settings(props) {
           props.loader(false);
         }).catch(e => {
           props.loader(false);
+          error(e.message || String(e));
         })
       break;
       case "3party":
@@ -72,6 +73,7 @@ function Settings(props) {
       if (principals.some(p => p.identity.principal === identity.principal)) return error("This Principal is already added to your wallet");
       dispatch({ type: 'addwallet', payload : {identity : identity}});
     }).catch(e => {
+      error(e.message || String(e));
     }).finally(() => {      
       props.loader(false);
       setInitialRoute('');


### PR DESCRIPTION
Several auth flows had empty `.catch(e => {})` blocks, so failures turned the loader off with **zero user feedback** — the user couldn't tell the action failed.

- `src/views/Settings.js`: report errors when linking an Internet Identity and when adding/importing a wallet.
- `src/containers/Unlock.js`: report errors in `iiLogin`.

Each now calls the existing `error()` helper with the failure message. Only the failure path changes; success is untouched.

Verified: full build + headless smoke test pass.