### PR TITLE
refactor: drop unused result vars in clipboard fallback

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -13,8 +13,7 @@ function fallbackCopyTextToClipboard(text) {
   textArea.select();
 
   try {
-    var successful = document.execCommand('copy');
-    var msg = successful ? 'successful' : 'unsuccessful';
+    document.execCommand('copy');
   } catch (err) {
     console.error('Fallback: Oops, unable to copy', err);
   }


### PR DESCRIPTION
In `src/utils.js`, `fallbackCopyTextToClipboard` computed `var successful = document.execCommand('copy')` and `var msg = successful ? ... : ...` — neither was ever used. Removed the dead assignments, keeping the `execCommand('copy')` call and its `try/catch`. No behavior change.

Verified: full build + headless smoke test pass.