### PR TITLE
fix: correct API-key preview slice and 'Identity' typo

### DIFF
--- a/src/components/ConnectList.js
+++ b/src/components/ConnectList.js
@@ -38,7 +38,7 @@ export default function ConnectList(props) {
           <AllInclusiveIcon />
         </ListItemIcon>
         <ListItemText 
-          primary={props.add ? "Link your Internet Identitiy" : "Link your Internet Identitiy" }
+          primary={props.add ? "Link your Internet Identity" : "Link your Internet Identity" }
           secondary={props.add ? "I want to link another Wallet using an Internet Identity" : "I want to link a Wallet using an Internet Identity" }
         />
       </ListItem>

--- a/src/views/Applications.js
+++ b/src/views/Applications.js
@@ -58,7 +58,7 @@ function Applications(props) {
                 <TableCell>
                   <a href={app.host} target="_blank" rel="noreferrer">{app.host}</a>
                 </TableCell>
-                <TableCell>{app.apikey.substr(48, 80)}...</TableCell>
+                <TableCell>{app.apikey.substr(0, 8)}...</TableCell>
                 <TableCell align="right">
                   <Tooltip title="Remove from Stoic">
                     <IconButton aria-label="Remove application" onClick={() => deleteApp(app.host)}>


### PR DESCRIPTION
Two small user-visible display fixes:

- `src/views/Applications.js`: the API-key cell used `app.apikey.substr(48, 80)` — `substr(start, length)`, so it showed characters 48–128 (usually a mid-string fragment or empty) then `...`. Changed to `substr(0, 8)` for a recognizable leading preview.
- `src/components/ConnectList.js`: fixed the typo "Internet Identitiy" -> "Internet Identity" (both branches).

Verified: full build + headless smoke test pass.