### PR TITLE
a11y: remove duplicate aria-label on toolbar icon buttons

### DIFF
--- a/src/containers/Wallet.js
+++ b/src/containers/Wallet.js
@@ -121,7 +121,6 @@ function Wallet(props) {
         <Toolbar>
           <IconButton
             color="inherit"
-            aria-label="open drawer"
             edge="start"
             aria-label="Toggle navigation menu" onClick={handleDrawerToggle}
             className={classes.menuButton}
@@ -135,7 +134,6 @@ function Wallet(props) {
           <div className={classes.toolbarButtons}>
             <IconButton
               color="inherit"
-              aria-label="settings"   
               edge="end"
               aria-label="Settings" onClick={() => changeRoute('settings')}
             >


### PR DESCRIPTION
In `src/containers/Wallet.js`, the drawer-toggle and settings `IconButton`s each had **two** `aria-label` attributes. JSX keeps the last, so the first (`"open drawer"`, `"settings"`) was silently shadowed — and duplicate props trigger the `jsx-a11y` / `react/jsx-no-duplicate-props` lint warning.

Removed the shadowed duplicates, keeping the descriptive labels (`"Toggle navigation menu"`, `"Settings"`). No visual change.

Verified: full build + headless smoke test pass.