### PR TITLE
docs: update Node version and toolchain to Node 20 / CRACO

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,10 +4,10 @@ Thanks for helping improve Stoic Wallet!
 
 ## Development setup
 
-This is a Create React App project that currently requires **Node 16** (see `.nvmrc`).
+This is a Create React App project (built with CRACO / react-scripts 5) that requires **Node 20** (see `.nvmrc`).
 
 ```bash
-nvm use            # Node 16
+nvm use            # Node 20
 npm install
 npm start          # http://localhost:3000
 npm test           # run unit tests

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ Note: the redirect does not require any approvals or whitelisting from Stoic. It
 
 ## Local development
 
-Stoic Wallet is a [Create React App](https://create-react-app.dev/) project.
+Stoic Wallet is a [Create React App](https://create-react-app.dev/) project built with [CRACO](https://craco.js.org/) (react-scripts 5 / webpack 5).
 
 ### Prerequisites
 
-- **Node.js 16** — the `react-scripts@4` toolchain doesn't build on Node ≥ 17.
-  Use [nvm](https://github.com/nvm-sh/nvm): `nvm install 16 && nvm use 16` (see `.nvmrc`).
+- **Node.js 20** (see `.nvmrc` and the `engines` field in `package.json`).
+  Use [nvm](https://github.com/nvm-sh/nvm): `nvm install 20 && nvm use 20`.
 
 ### Install & run
 
@@ -25,9 +25,6 @@ npm start          # dev server at http://localhost:3000
 ```bash
 npm run build      # outputs to ./build
 ```
-
-> If a build fails with an OpenSSL error on a newer Node, prefix with
-> `NODE_OPTIONS=--openssl-legacy-provider`.
 
 ### Notes
 


### PR DESCRIPTION
README and CONTRIBUTING still told contributors to use **Node 16** and described a `react-scripts@4` CRA toolchain — but the repo migrated to **react-scripts 5 / CRACO / Node 20** (`.nvmrc` = `20.18.1`, `engines: ">=20"`, scripts use `craco`). The old `nvm install 16` instruction does not build the project.

- README: Node 20 prerequisite, note the CRACO/RS5 build, removed the obsolete `--openssl-legacy-provider` workaround.
- CONTRIBUTING: Node 20, mention CRACO.

Docs-only; no build/runtime impact.