### PR TITLE
ci(dependabot): switch Dependabot to security-updates-only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,33 +1,22 @@
 version: 2
+# Dependabot is configured for SECURITY UPDATES ONLY.
+#
+# Routine version-update PRs are disabled below via `open-pull-requests-limit: 0`.
+# This app has tightly-coupled, pinned stacks (@dfinity/*, React, CRA) whose major
+# bumps can't be applied automatically, so the weekly version PRs were just noise.
+#
+# Security updates are NOT affected by this limit: when a dependency has a known
+# vulnerability, Dependabot will still open a PR. (Make sure "Dependabot security
+# updates" is enabled under Settings -> Advanced Security.)
+#
+# No `ignore` rules here on purpose — `ignore` can also suppress security PRs, and
+# we never want to silence a vulnerability fix. To resume routine version bumps,
+# raise the limit and re-add the grouping/ignore rules from git history.
 updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 0
     labels:
       - "dependencies"
-    groups:
-      # Batch low-risk updates into one PR to cut review noise
-      minor-and-patch:
-        update-types:
-          - "minor"
-          - "patch"
-    ignore:
-      # The @dfinity/* agent stack is tightly coupled and pinned at 0.9.x.
-      # These are 0.x packages, so a 0.9 -> 0.14 bump is a *minor* in semver terms
-      # but still breaking — it must be upgraded as a coordinated, tested whole
-      # (see #55/#128). Allow only patch updates here; do majors/minors by hand.
-      - dependency-name: "@dfinity/*"
-        update-types:
-          - "version-update:semver-major"
-          - "version-update:semver-minor"
-      # react + react-dom must move together as a deliberate framework upgrade,
-      # never as a lone dependabot bump (see #126, react-dom 17 -> 19 mismatch).
-      - dependency-name: "react"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "react-dom"
-        update-types: ["version-update:semver-major"]
-      # react-scripts / CRA toolchain majors are handled by the migration (#107).
-      - dependency-name: "react-scripts"
-        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## What
Reconfigures Dependabot to **only** open PRs for known security vulnerabilities, and stop the routine weekly version bumps.

- `open-pull-requests-limit: 0` disables scheduled **version-update** PRs.
- **Security updates are unaffected** by that limit — Dependabot still opens a PR when a dependency has a CVE.
- Removed the `ignore` rules: `ignore` can also suppress *security* PRs, and we never want to silence a vulnerability fix. (The coupling concern only applied to routine version bumps, which are now off.)

## Why
This is a crypto wallet, so automatic alerts on vulnerable dependencies are genuinely valuable. But the app has tightly-coupled, pinned stacks (`@dfinity/*`, React, CRA) whose majors can't be applied automatically — so the weekly version PRs were noise you couldn't merge.

## Action required (repo settings, not in this file)
Dependabot **alerts** and **security updates** are currently **disabled** on this repo. For security-only mode to do anything, enable both under **Settings -> Advanced Security / Code security and analysis**. Config alone can't turn these on.

Existing routine PR #124 (`testing-library` 11->16) can be closed — it's a version bump, not a security fix.
