### PR TITLE
fix: remove expired, unreferenced origin-trial token

### DIFF
--- a/public/trials.js
+++ b/public/trials.js
@@ -1,5 +1,0 @@
-const TOKEN = 'A9w/5kIDoN3pHZBOFwUHJhRxquUb/HT7mYokKy/zslmTKnopv9SIYB+6NYwlaQDsKqFTjSNG4RB4boZKB6PlcA8AAACUeyJvcmlnaW4iOiJodHRwczovL3N0b2ljd2FsbGV0LmNvbTo0NDMiLCJmZWF0dXJlIjoiRGlzYWJsZVRoaXJkUGFydHlTdG9yYWdlUGFydGl0aW9uaW5nIiwiZXhwaXJ5IjoxNzI1NDA3OTk5LCJpc1N1YmRvbWFpbiI6dHJ1ZSwiaXNUaGlyZFBhcnR5Ijp0cnVlfQ==';
-const otMeta = document.createElement('meta');
-otMeta.httpEquiv = 'origin-trial';
-otMeta.content = TOKEN;
-document.head.append(otMeta);


### PR DESCRIPTION
Closes #78.

`public/trials.js` injected a `DisableThirdPartyStoragePartitioning` origin-trial token that **expired 2024-09-04**. It is also **not referenced** anywhere (`index.html` does not load it, nothing imports it) — so it was dead code shipping an expired token.

This removes the file. If the origin trial is actually wanted, it needs a freshly-registered token wired into `index.html` explicitly — happy to do that in a follow-up if you register a new token for the domain.
