### PR TITLE
security: scope postMessage auth responses to the sender origin

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -179,6 +179,8 @@ function buf2hex(buffer) {
     .join('');
 }
 const sendMessageToExtension = (e, success, data) => {
+  // #69: never respond to opaque/empty origins, and never broadcast to '*'
+  if (!e.origin || e.origin === 'null') return;
   let response = {
     action : e.data.action,
     listener : e.data.listener,
@@ -192,9 +194,9 @@ const sendMessageToExtension = (e, success, data) => {
     if (e.data.endpoint === 'call') {
       response.complete = false;
     }
-    window.opener.postMessage(response, e.origin || '*');
+    window.opener.postMessage(response, e.origin);
   } else {
-    window.parent.postMessage(response, e.origin || '*');
+    window.parent.postMessage(response, e.origin);
   }
 }
 const verify = async (data, apikey, sig) => {
@@ -379,6 +381,8 @@ if (params.get('stoicTunnel') !== null) {
   
   if (params.get('transport') !== null && params.get('transport') === "popup" && params.get('lid') !== null) {
     window.onload= () => {
+      // '*' is intentional: load ping sent before the opener origin is known;
+      // carries only the listener id, no sensitive data.
       window.opener.postMessage({
         action : "stoicPopupLoad",
         listener : params.get('lid'),

--- a/src/views/AccountDetail.js
+++ b/src/views/AccountDetail.js
@@ -119,6 +119,8 @@ function AccountDetail(props) {
       window.addEventListener(
         'message',
         function (e) {
+          // #69: ignore opaque/empty origins; never broadcast auth responses to '*'
+          if (!e.origin || e.origin === 'null') return;
           if (e.source === window.opener) {
             if (e.data.action === 'requestAuthorization') {
               var app = apps.find(a => a.host === e.origin);
@@ -131,7 +133,7 @@ function AccountDetail(props) {
                   : 'Standard',
               };
               if (app && app.apikey === e.data.apikey) {
-                window.opener.postMessage(authResponse, e.origin || '*');
+                window.opener.postMessage(authResponse, e.origin);
               } else {
                 props
                   .confirm(
@@ -156,9 +158,9 @@ function AccountDetail(props) {
                         app.apikey = e.data.apikey;
                         dispatch({type: 'app/edit', payload: {app: app}});
                       }
-                      window.opener.postMessage(authResponse, e.origin || '*');
+                      window.opener.postMessage(authResponse, e.origin);
                     } else {
-                      window.opener.postMessage({action: 'rejectAuthorization'}, e.origin || '*');
+                      window.opener.postMessage({action: 'rejectAuthorization'}, e.origin);
                     }
                   });
               }
@@ -167,6 +169,8 @@ function AccountDetail(props) {
         },
         false,
       );
+      // '*' is intentional here: the handshake trigger is sent before the opener
+      // origin is known and carries no sensitive data (unlike the auth responses).
       window.opener.postMessage({action: 'initiateStoicConnect'}, '*');
     }
     const nfttransfer = params.get('nftTx');


### PR DESCRIPTION
Closes #69.

Building on the inbound-origin guard from #86, this removes the wildcard target on **auth responses** — which carry the user's **principal and public key** and must never be broadcast to `'*'`.

### Changes
- **`src/index.js`** (`sendMessageToExtension`): guard against opaque/empty origins (mirrors #86), and send responses to `e.origin` instead of `e.origin || '*'`.
- **`src/views/AccountDetail.js`** (authorization handler): add the same opaque-origin guard at the top of the listener, and send `confirmAuthorization` / `rejectAuthorization` responses to `e.origin` instead of `e.origin || '*'`.
- The **two remaining `'*'` sends** (`initiateStoicConnect`, `stoicPopupLoad`) are intentional and now commented: they're handshake/load pings issued **before** the opener's origin is known and carry **no sensitive data**.

### Verification
`npm run build` passes. No behavioural change for legitimate dapp connections (which always have a concrete origin); only opaque/`null` origins — which can't be trusted with auth data — are now refused instead of wildcarded.
