### PR TITLE
refactor: drop dead renderView cases and dedupe identical ones

### DIFF
--- a/src/containers/Wallet.js
+++ b/src/containers/Wallet.js
@@ -86,17 +86,11 @@ function Wallet(props) {
   };
   const renderView = (r) => {
     switch(r){
-      case "accountDetail":
-        return React.createElement(routes[r].view, {alert : props.alert, confirm : props.confirm, loader : props.loader})
       case "settings":
         return React.createElement(routes[r].view, {alert : props.alert, confirm : props.confirm, loader : props.loader, clearWallet : clearWallet, lockWallet : lockWallet})
+      case "accountDetail":
       case "neurons":
-        return React.createElement(routes[r].view, {alert : props.alert, confirm : props.confirm, loader : props.loader})
       case "applications":
-        return React.createElement(routes[r].view, {alert : props.alert, confirm : props.confirm, loader : props.loader})
-      case "marketplace":
-        return React.createElement(routes[r].view, {alert : props.alert, confirm : props.confirm, loader : props.loader})
-      case "tokenregistry":
         return React.createElement(routes[r].view, {alert : props.alert, confirm : props.confirm, loader : props.loader})
       default:
         return React.createElement(routes[r].view, {alert : props.alert, confirm : props.confirm})


### PR DESCRIPTION
`Wallet.renderView` had `case "marketplace"` and `case "tokenregistry"` that:
- are **not** in the `routes` map (`accountDetail`, `neurons`, `applications`, `addressBook`, `settings`), and
- are **never navigated to** anywhere in the app.

So they were dead code — and if either were ever reached, `routes[r].view` would throw (`routes['marketplace']` is `undefined`). This removes them, and collapses the three remaining **identical** cases (`accountDetail` / `neurons` / `applications`) into a single fall-through.

No behaviour change for any real route. `npm run build` passes.
