### PR TITLE
safety: prevent double-submit on send / topup / NFT-transfer dialogs

### DIFF
--- a/src/components/SendForm.js
+++ b/src/components/SendForm.js
@@ -39,6 +39,7 @@ export default function SendForm(props) {
   const [notify, setNotify] = React.useState(false);
 
   const [contacts, setContacts] = React.useState([]);
+  const submitting = React.useRef(false);
 
   //cold API
   const api = extjs.connect('https://icp0.io/');
@@ -78,6 +79,8 @@ export default function SendForm(props) {
     const id = StoicIdentity.getIdentity(identity.principal);
     if (!id) return error('Something wrong with your wallet, try logging in again');
 
+    if (submitting.current) return;
+    submitting.current = true;
     props.loader(true);
     handleClose();
     //hot api, will sign as identity - BE CAREFUL
@@ -98,6 +101,7 @@ export default function SendForm(props) {
       })
       .finally(() => {
         props.loader(false);
+        submitting.current = false;
       });
   };
   const sendMax = () => {

--- a/src/components/SendNFTForm.js
+++ b/src/components/SendNFTForm.js
@@ -39,6 +39,7 @@ export default function SendNFTForm(props) {
       return error('Please enter a valid address to send to');
     setStep(1);
   };
+  const submitting = React.useRef(false);
   const submit = async () => {
     var _from_principal = identity.principal;
     var _from_sa = currentAccount;
@@ -49,6 +50,8 @@ export default function SendNFTForm(props) {
     var _notify = false;
     const id = StoicIdentity.getIdentity(identity.principal);
     if (!id) return error('Something wrong with your wallet, try logging in again');
+    if (submitting.current) return;
+    submitting.current = true;
     props.loader(true);
     handleClose();
     try {
@@ -66,6 +69,7 @@ export default function SendNFTForm(props) {
       error('There was an error: ' + (e.message || e));
     }
     props.loader(false);
+    submitting.current = false;
   };
 
   const handleClose = () => {

--- a/src/components/TopupForm.js
+++ b/src/components/TopupForm.js
@@ -41,6 +41,7 @@ export default function TopupForm(props) {
     if (Number(amount) + Number(fee) > balance) return error('You have insufficient ICP');
     setStep(1);
   };
+  const submitting = React.useRef(false);
   const submit = () => {
     //Submit to blockchain here
     var _from_principal = identity.principal;
@@ -52,6 +53,8 @@ export default function TopupForm(props) {
     const id = StoicIdentity.getIdentity(identity.principal);
     if (!id) return error('Something wrong with your wallet, try logging in again');
 
+    if (submitting.current) return;
+    submitting.current = true;
     props.loader(true);
     handleClose();
 
@@ -71,6 +74,7 @@ export default function TopupForm(props) {
       })
       .finally(() => {
         props.loader(false);
+        submitting.current = false;
       });
   };
   const handleClick = () => {


### PR DESCRIPTION
Wallets like MetaMask and Phantom disable the confirm action the instant it's pressed so a transaction can't be sent twice. None of the three transfer dialogs guarded against this: a fast double-click fires the submit handler twice **synchronously** before the dialog closes, sending two transactions.

Adds a `useRef` re-entry guard to `SendForm`, `TopupForm`, and `SendNFTForm` — set before the async transfer begins and cleared when it settles — so a second click is a no-op. No visual change; pure safety on an irreversible money action.

Verified: build + headless smoke test pass.