### PR TITLE
ux: show loading skeletons instead of plain "Loading..." text

### DIFF
--- a/src/components/NFTCard.js
+++ b/src/components/NFTCard.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import Skeleton from '@material-ui/lab/Skeleton';
 import Card from '@material-ui/core/Card';
 import CardActionArea from '@material-ui/core/CardActionArea';
 import CardContent from '@material-ui/core/CardContent';
@@ -37,7 +38,7 @@ function NFTCard(props) {
               {props.title}
             </Typography>
             <Typography variant="h6" >
-            {props.count >= 0 ? props.count  : ''} {props.count >= 0 ? typeof props.count != "string" ? <> NFT{props.count === 1 ? "" : "s"}</> : "" : 'Loading...'}
+            {props.count >= 0 ? props.count  : ''} {props.count >= 0 ? typeof props.count != "string" ? <> NFT{props.count === 1 ? "" : "s"}</> : "" : <Skeleton variant="text" width={70} style={{display:'inline-block'}} />}
             </Typography>
             {/*<Typography style={styles.pos} color={props.selected ? "inherit" : "textSecondary"}>
               ~$123.04USD

--- a/src/components/Transactions.js
+++ b/src/components/Transactions.js
@@ -8,6 +8,7 @@ import TableRow from '@material-ui/core/TableRow';
 import Paper from '@material-ui/core/Paper';
 import Pagination from '@material-ui/lab/Pagination';
 import Typography from '@material-ui/core/Typography';
+import Skeleton from '@material-ui/lab/Skeleton';
 import Timestamp from 'react-timestamp';
 const formatNumber = n => {
   return n.toFixed(8).replace(/0{1,6}$/, '');
@@ -27,10 +28,10 @@ export default function Transactions(props) {
   return (
     <>
       {props.transactions === false ? (
-        <div style={styles.empty}>
-          <Typography paragraph style={{paddingTop: 20, fontWeight: 'bold'}} align="center">
-            Loading transactions...
-          </Typography>
+        <div style={{padding: '20px 0'}}>
+          {[...Array(5)].map((_, i) => (
+            <Skeleton key={i} variant="text" height={40} />
+          ))}
         </div>
       ) : props.transactions.length === 0 ? (
         <div style={styles.empty}>


### PR DESCRIPTION
Every modern wallet (Rainbow, Coinbase Wallet, Phantom) uses skeleton placeholders while data loads rather than a bare "Loading" string. This swaps the plain-text loading states for Material-UI `Skeleton`s:

- **Transactions**: the "Loading transactions..." line becomes a set of shimmering row skeletons.
- **NFTCard**: the per-collection "Loading..." count becomes an inline text skeleton.

The existing `=== false` loading sentinels are reused, so behaviour is unchanged once data arrives.

Verified: build + headless smoke test pass.