### PR TITLE
feat: privacy mode — a toggle to hide balances

### DIFF
--- a/src/balanceVisibility.js
+++ b/src/balanceVisibility.js
@@ -1,0 +1,4 @@
+import React from 'react';
+
+// Runtime-only (not persisted) flag for masking balances in the UI.
+export const BalanceVisibilityContext = React.createContext(false);

--- a/src/components/TokenCard.js
+++ b/src/components/TokenCard.js
@@ -6,6 +6,7 @@ import Typography from '@material-ui/core/Typography';
 import Grid from '@material-ui/core/Grid';
 import extjs from '../ic/extjs.js';
 import {useSelector} from 'react-redux';
+import {BalanceVisibilityContext} from '../balanceVisibility';
 
 const styles = {
   root: {
@@ -30,6 +31,7 @@ var intervalId = 0;
 const api = extjs.connect('https://icp0.io/');
 function TokenCard(props) {
   const [balance, setBalance] = React.useState(false);
+  const hideBalances = React.useContext(BalanceVisibilityContext);
   const currentPrincipal = useSelector(state => state.currentPrincipal);
   const identity = useSelector(state =>
     state.principals.length ? state.principals[currentPrincipal].identity : {},
@@ -71,7 +73,7 @@ function TokenCard(props) {
               {props.data.name}
             </Typography>
             <Typography variant="h6">
-              {balance === false ? 'Loading' : balance + ' ' + props.data.symbol}
+              {balance === false ? 'Loading' : hideBalances ? '••••••' : balance + ' ' + props.data.symbol}
             </Typography>
             {/*<Typography style={styles.pos} color={props.selected ? "inherit" : "textSecondary"}>
               ~$123.04USD

--- a/src/containers/Wallet.js
+++ b/src/containers/Wallet.js
@@ -5,10 +5,13 @@ import CssBaseline from '@material-ui/core/CssBaseline';
 import IconButton from '@material-ui/core/IconButton';
 import MenuIcon from '@material-ui/icons/Menu';
 import AccountCircleIcon from '@material-ui/icons/AccountCircle';
+import VisibilityIcon from '@material-ui/icons/Visibility';
+import VisibilityOffIcon from '@material-ui/icons/VisibilityOff';
 import Toolbar from '@material-ui/core/Toolbar';
 import Typography from '@material-ui/core/Typography';
 
 import AccountDrawer from '../components/AccountDrawer';
+import {BalanceVisibilityContext} from '../balanceVisibility';
 
 import AccountDetail from '../views/AccountDetail';
 import AddressBook from '../views/AddressBook';
@@ -108,6 +111,7 @@ function Wallet(props) {
   const clearWallet = () => {
     props.remove();
   };
+  const [hideBalances, setHideBalances] = React.useState(false);
   return (
     <div className={classes.root}>
       <CssBaseline />
@@ -128,6 +132,13 @@ function Wallet(props) {
           <div className={classes.toolbarButtons}>
             <IconButton
               color="inherit"
+              aria-label={hideBalances ? 'Show balances' : 'Hide balances'}
+              onClick={() => setHideBalances(v => !v)}
+            >
+              {hideBalances ? <VisibilityOffIcon /> : <VisibilityIcon />}
+            </IconButton>
+            <IconButton
+              color="inherit"
               edge="end"
               aria-label="Settings" onClick={() => changeRoute('settings')}
             >
@@ -139,7 +150,9 @@ function Wallet(props) {
       <AccountDrawer lockWallet={lockWallet} changeRoute={changeRoute} onClose={handleDrawerClose} open={mobileOpen} />
       <main className={classes.content}>
         <div className={classes.toolbar} />
-          {renderView(route)}
+          <BalanceVisibilityContext.Provider value={hideBalances}>
+            {renderView(route)}
+          </BalanceVisibilityContext.Provider>
       </main>
     </div>
   );


### PR DESCRIPTION
A staple of Trust Wallet, Coinbase Wallet, and Phantom: an eye icon to mask your balances (useful when screen-sharing or in public).

Adds a `Visibility`/`VisibilityOff` toggle in the app bar. When on, token balances render as `••••••`. State is held at the `Wallet` level and shared via a small React context (`balanceVisibility.js`) consumed by `TokenCard` — **runtime-only, not persisted**, so it resets on reload (no storage/DB schema change).

Verified: build + headless smoke test pass.