### PR TITLE
ux: highlight the active item in the navigation drawer

### DIFF
--- a/src/components/AccountDrawer.js
+++ b/src/components/AccountDrawer.js
@@ -40,6 +40,7 @@ export default function AccountDrawer(props) {
   const theme = useTheme();
   const container = window !== undefined ? () => window().document.body : undefined;
   const currentPrincipal = useSelector(state => state.currentPrincipal)
+  const currentAccount = useSelector(state => state.currentAccount)
   const accounts = useSelector(state => (state.principals.length ? state.principals[currentPrincipal].accounts : []))
   const idtype = useSelector(state => (state.principals.length ? state.principals[currentPrincipal].identity.type : ""));
   const principal = useSelector(state => (state.principals.length ? state.principals[currentPrincipal].identity.principal : ""));
@@ -62,7 +63,7 @@ export default function AccountDrawer(props) {
         {accounts.map((account, index) => {
           return (
             <div key={index}>
-              <ListItem button onClick={() => {props.onClose(); props.changeRoute('accountDetail', index)}}>
+              <ListItem button selected={props.route === 'accountDetail' && currentAccount === index} onClick={() => {props.onClose(); props.changeRoute('accountDetail', index)}}>
                 <ListItemAvatar>
                   <Avatar>
                     <Blockie address={account.address} />
@@ -88,15 +89,15 @@ export default function AccountDrawer(props) {
       </List>
       <Divider />
       <List>
-        <ListItem button onClick={() => {props.onClose(); props.changeRoute('addressBook')}}>
+        <ListItem button selected={props.route === 'addressBook'} onClick={() => {props.onClose(); props.changeRoute('addressBook')}}>
           <ListItemIcon><PeopleIcon /></ListItemIcon>
           <ListItemText primary="Address Book" />
         </ListItem>
-        <ListItem button onClick={() => {props.onClose(); props.changeRoute('neurons')}}>
+        <ListItem button selected={props.route === 'neurons'} onClick={() => {props.onClose(); props.changeRoute('neurons')}}>
           <ListItemIcon><AllInclusiveIcon /></ListItemIcon>
           <ListItemText primary="Neurons" />
         </ListItem>
-        <ListItem button onClick={() => {props.onClose(); props.changeRoute('applications')}}>
+        <ListItem button selected={props.route === 'applications'} onClick={() => {props.onClose(); props.changeRoute('applications')}}>
           <ListItemIcon><AppsIcon /></ListItemIcon>
           <ListItemText primary="Applications" />
         </ListItem>

--- a/src/containers/Wallet.js
+++ b/src/containers/Wallet.js
@@ -136,7 +136,7 @@ function Wallet(props) {
           </div>
         </Toolbar>
       </AppBar>
-      <AccountDrawer lockWallet={lockWallet} changeRoute={changeRoute} onClose={handleDrawerClose} open={mobileOpen} />
+      <AccountDrawer route={route} lockWallet={lockWallet} changeRoute={changeRoute} onClose={handleDrawerClose} open={mobileOpen} />
       <main className={classes.content}>
         <div className={classes.toolbar} />
           {renderView(route)}


### PR DESCRIPTION
In every wallet the current section is visibly selected in the side nav. The drawer here highlighted nothing. This threads the current `route` (and `currentAccount`) into `AccountDrawer` and uses Material-UI's native `selected` prop to highlight the active account and the active section (Address Book / Neurons / Applications).

Verified: build + headless smoke test pass.