### PR TITLE
ux: friendlier empty states for NFTs and transactions

### DIFF
--- a/src/components/NFTList.js
+++ b/src/components/NFTList.js
@@ -1,5 +1,7 @@
 /* global BigInt */
 import React from 'react';
+import CollectionsIcon from '@material-ui/icons/Collections';
+import Skeleton from '@material-ui/lab/Skeleton';
 import Divider from '@material-ui/core/Divider';
 import FormControl from '@material-ui/core/FormControl';
 import InputLabel from '@material-ui/core/InputLabel';
@@ -228,9 +230,20 @@ export default function NFTList(props) {
       </span>
       {props.nfts === false || props.nfts.filter(a => collection === false || a.canister === collection).length === 0 ? (
         <div style={styles.empty}>
-          <Typography paragraph style={{paddingTop: 20, fontWeight: 'bold'}} align="center">
-            {props.nfts === false ? "Loading NFTs..." : "You have no NFT's right now"}
-          </Typography>
+          {props.nfts === false ? (
+            <div style={{paddingTop: 20}}>
+              {[...Array(4)].map((_, i) => (
+                <Skeleton key={i} variant="text" height={40} />
+              ))}
+            </div>
+          ) : (
+            <>
+              <CollectionsIcon style={{fontSize: 48, color: '#ccc', display: 'block', margin: '20px auto 0'}} />
+              <Typography paragraph style={{paddingTop: 10, fontWeight: 'bold'}} align="center">
+                You have no NFT's right now
+              </Typography>
+            </>
+          )}
         </div>
       ) : (
         <>

--- a/src/components/Transactions.js
+++ b/src/components/Transactions.js
@@ -7,6 +7,7 @@ import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
 import Paper from '@material-ui/core/Paper';
 import Pagination from '@material-ui/lab/Pagination';
+import ReceiptIcon from '@material-ui/icons/Receipt';
 import Typography from '@material-ui/core/Typography';
 import Timestamp from 'react-timestamp';
 const formatNumber = n => {
@@ -34,7 +35,8 @@ export default function Transactions(props) {
         </div>
       ) : props.transactions.length === 0 ? (
         <div style={styles.empty}>
-          <Typography paragraph style={{paddingTop: 20, fontWeight: 'bold'}} align="center">
+          <ReceiptIcon style={{fontSize: 48, color: '#ccc', display: 'block', margin: '20px auto 0'}} />
+          <Typography paragraph style={{paddingTop: 10, fontWeight: 'bold'}} align="center">
             No transactions available
           </Typography>
         </div>


### PR DESCRIPTION
Empty lists showed a lone bold line of text. Wallets like Rainbow pair an icon/illustration with the message so the screen doesn't feel broken. Adds an icon above the existing copy:

- **NFTs**: a `Collections` icon above "You have no NFT's right now" (and the loading branch now shows skeletons).
- **Transactions**: a `Receipt` icon above "No transactions available".

Verified: build + headless smoke test pass.