### PR TITLE
a11y: tooltip on the NFT "More actions" button

### DIFF
--- a/src/components/NFTList.js
+++ b/src/components/NFTList.js
@@ -322,6 +322,7 @@ export default function NFTList(props) {
                         <TableCell align="right">
                           <>
                             <>
+                              <Tooltip title="More actions">
                               <IconButton
                                 aria-label="More actions" id={'more-' + nft.tokenid}
                                 size="small"
@@ -332,6 +333,7 @@ export default function NFTList(props) {
                               >
                                 <MoreVertIcon />
                               </IconButton>
+                              </Tooltip>
                               <Menu
                                 anchorEl={
                                   anchorEl !== null && anchorEl.id === nft.tokenid


### PR DESCRIPTION
The per-NFT overflow (`⋮`) button had an `aria-label` but no visible tooltip, unlike the neighbouring "View in browser" button which already has one. Wraps it in a Material-UI `Tooltip` ("More actions") for discoverability and consistency.

Verified: build + headless smoke test pass.