### PR TITLE
ux: submit the unlock form when pressing Enter

### DIFF
--- a/src/containers/Unlock.js
+++ b/src/containers/Unlock.js
@@ -195,6 +195,7 @@ function Unlock(props) {
                 type="password" autoComplete="off"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
+                onKeyDown={(e) => { if (e.key === 'Enter') loginPassword(); }}
               />
             </DialogContent>
             <DialogActions>


### PR DESCRIPTION
Unlocking the wallet is the most frequent action, but the password field ignored the Enter key — you had to click "Unlock". Every wallet submits its unlock/password screen on Enter. Adds an `onKeyDown` handler so Enter triggers `loginPassword()`.

Verified: build + headless smoke test pass.