### PR TITLE
feat: show a receive QR code for the account address

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "path-browserify": "^1.0.1",
         "postinstall-postinstall": "^2.1.0",
         "process": "^0.11.10",
+        "qrcode.react": "^3.1.0",
         "querystring-es3": "^0.2.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -18213,6 +18214,15 @@
         "teleport": ">=0.2.0"
       }
     },
+    "node_modules/qrcode.react": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-3.2.0.tgz",
+      "integrity": "sha512-YietHHltOHA4+l5na1srdaMx4sVSOjV9tamHs+mwiLWAMr6QVACRUw1Neax5CptFILcNoITctJY0Ipyn5enQ8g==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/qs": {
       "version": "6.15.3",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
@@ -36318,6 +36328,11 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
       "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw=="
+    },
+    "qrcode.react": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-3.2.0.tgz",
+      "integrity": "sha512-YietHHltOHA4+l5na1srdaMx4sVSOjV9tamHs+mwiLWAMr6QVACRUw1Neax5CptFILcNoITctJY0Ipyn5enQ8g=="
     },
     "qs": {
       "version": "6.15.3",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "json-bigint": "^1.0.0",
     "patch-package": "^6.4.7",
     "postinstall-postinstall": "^2.1.0",
+    "qrcode.react": "^3.1.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-redux": "^7.2.4",

--- a/src/views/AccountDetail.js
+++ b/src/views/AccountDetail.js
@@ -393,7 +393,7 @@ function AccountDetail(props) {
                       size="small"
                       label="Address"
                     />{' '}
-                    <Tooltip title={account.address}><span>{account.address.substr(0, 29) + '...'}</span></Tooltip>
+                    <Tooltip title={account.address}><span>{account.address.slice(0, 29) + '...'}</span></Tooltip>
                   </span>
                   <SnackbarButton
                     message="Address Copied"
@@ -424,7 +424,7 @@ function AccountDetail(props) {
                         size="small"
                         label="Principal ID"
                       />{' '}
-                      <Tooltip title={principal}><span>{principal.substr(0, 32) + '...'}</span></Tooltip>
+                      <Tooltip title={principal}><span>{principal.slice(0, 32) + '...'}</span></Tooltip>
                     </span>
                     <SnackbarButton
                       message="Principal ID Copied"

--- a/src/views/AccountDetail.js
+++ b/src/views/AccountDetail.js
@@ -20,6 +20,7 @@ import EvStationIcon from '@material-ui/icons/EvStation';
 import {useTheme} from '@material-ui/core/styles';
 import Tooltip from '@material-ui/core/Tooltip';
 import Blockie from '../components/Blockie';
+import {QRCodeCanvas} from 'qrcode.react';
 import SnackbarButton from '../components/SnackbarButton';
 import TokenCard from '../components/TokenCard';
 import NFTCard from '../components/NFTCard';
@@ -441,6 +442,12 @@ function AccountDetail(props) {
                 ) : (
                   ''
                 )}
+                <div style={{textAlign: 'center', margin: '15px 0'}}>
+                  <QRCodeCanvas value={account.address} size={128} includeMargin />
+                  <div style={{fontSize: '0.8em', color: '#888', marginTop: 5}}>
+                    Scan to receive ICP &amp; tokens
+                  </div>
+                </div>
               </>
             }
           />


### PR DESCRIPTION
Every wallet's receive screen shows a scannable QR of the address (MetaMask, Phantom, Trust). The account header showed only the truncated text address. This renders a QR code of the account address in the header with a "Scan to receive ICP & tokens" caption.

Adds one small, widely-used dependency: `qrcode.react` (`^3.1.0`).

Verified: build + headless smoke test pass.