### PR TITLE
ux: show the full address / principal on hover

### DIFF
--- a/src/views/AccountDetail.js
+++ b/src/views/AccountDetail.js
@@ -392,7 +392,7 @@ function AccountDetail(props) {
                       size="small"
                       label="Address"
                     />{' '}
-                    {account.address.substr(0, 29) + '...'}
+                    <Tooltip title={account.address}><span>{account.address.substr(0, 29) + '...'}</span></Tooltip>
                   </span>
                   <SnackbarButton
                     message="Address Copied"
@@ -423,7 +423,7 @@ function AccountDetail(props) {
                         size="small"
                         label="Principal ID"
                       />{' '}
-                      {principal.substr(0, 32) + '...'}
+                      <Tooltip title={principal}><span>{principal.substr(0, 32) + '...'}</span></Tooltip>
                     </span>
                     <SnackbarButton
                       message="Principal ID Copied"


### PR DESCRIPTION
The account address and principal are displayed truncated (`abc…`). Before sending, users want to confirm the full value without copying it out — hovering to reveal the full string is the common pattern (Etherscan, block explorers). Wraps the truncated address and principal in a `Tooltip` showing the full value. (Copy already works and is unchanged.)

Verified: build + headless smoke test pass.