### PR TITLE
ux: show account count, first-account blockie & address in the principal switcher

### DIFF
--- a/src/containers/Unlock.js
+++ b/src/containers/Unlock.js
@@ -115,19 +115,23 @@ function Unlock(props) {
             aria-labelledby="settings-list"
           >
             {principals.map((principal, i) => {
+              const firstAccount = principal.accounts[0];
+              const accountCount = principal.accounts.length;
               return (
-              <ListItem key={principal.identity.principal} button onClick={() => changePrincipal(i)}>
+              <ListItem key={principal.identity.principal} button selected={i === currentPrincipal} onClick={() => changePrincipal(i)}>
                 <ListItemAvatar>
                   <Avatar>
-                    <Blockie address={principal.identity.principal ?? ''} />
+                    <Blockie address={firstAccount ? firstAccount.address : (principal.identity.principal ?? '')} />
                   </Avatar>
                 </ListItemAvatar>
                 <ListItemText 
                   primaryTypographyProps={{noWrap:true}} 
+                  secondaryTypographyProps={{noWrap:true, component:'span'}}
                   primary={principal.identity.principal}
                   secondary={
                     <>
-                      <>{identityTypes[principal.identity.type]}</>
+                      {identityTypes[principal.identity.type]} · {accountCount} account{accountCount === 1 ? '' : 's'}
+                      {firstAccount ? <><br />{firstAccount.address.substr(0, 24) + '…'}</> : ''}
                     </>
                   } />
               </ListItem>) 


### PR DESCRIPTION
Addresses the core of #166 — *"it's hard to remember which principal belongs to which set of accounts"*.

The **Select a Principal** switcher now shows, for each principal:
- the **blockie and truncated address of the first account** (so you recognise the wallet at a glance),
- the **number of accounts** it holds (`N accounts`),
- a **highlight** on the currently-selected principal.

No store/persistence changes — purely derived from data already in state. Verified: `npm run build` passes on Node 20.

Follow-ups for the rest of #166 are coming as separate PRs: **naming principals**, and a note on the **last-known balance** request (the wallet doesn't currently cache balances, so I'll propose how to do that).