### PR TITLE
feat: let users name their principals

### DIFF
--- a/src/containers/Unlock.js
+++ b/src/containers/Unlock.js
@@ -8,6 +8,10 @@ import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
 import ListItemText from '@material-ui/core/ListItemText';
+import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction';
+import IconButton from '@material-ui/core/IconButton';
+import EditIcon from '@material-ui/icons/Edit';
+import InputForm from '../components/InputForm';
 import AllInclusiveIcon from '@material-ui/icons/AllInclusive';
 import InsertDriveFileIcon from '@material-ui/icons/InsertDriveFile';
 import TextField from '@material-ui/core/TextField';
@@ -61,6 +65,9 @@ function Unlock(props) {
         props.remove();
       }
     });
+  };
+  const renamePrincipal = (index, name) => {
+    dispatch({ type: 'principal/edit', payload : {index : index, name : (name || '').trim()}});
   };
   const changePrincipal = (p) => {
     dispatch({ type: 'currentPrincipal', payload : {index : p}});
@@ -127,13 +134,27 @@ function Unlock(props) {
                 <ListItemText 
                   primaryTypographyProps={{noWrap:true}} 
                   secondaryTypographyProps={{noWrap:true, component:'span'}}
-                  primary={principal.identity.principal}
+                  primary={principal.name ? principal.name : principal.identity.principal}
                   secondary={
                     <>
                       {identityTypes[principal.identity.type]} · {accountCount} account{accountCount === 1 ? '' : 's'}
                       {firstAccount ? <><br />{firstAccount.address.substr(0, 24) + '…'}</> : ''}
                     </>
                   } />
+                <ListItemSecondaryAction>
+                  <InputForm
+                    title="Name this principal"
+                    content="Give this principal a memorable name to tell it apart when switching."
+                    inputLabel="Principal name"
+                    buttonLabel="Save"
+                    defaultValue={principal.name ?? ''}
+                    onClick={(name) => renamePrincipal(i, name)}
+                  >
+                    <IconButton edge="end" aria-label="Name this principal" size="small">
+                      <EditIcon fontSize="small" />
+                    </IconButton>
+                  </InputForm>
+                </ListItemSecondaryAction>
               </ListItem>) 
             })}
           </List>

--- a/src/store.js
+++ b/src/store.js
@@ -55,6 +55,7 @@ function initDb(_db){
         accounts : [],
         neurons : [],
         apps : [],
+        name : principal.name,
         identity : principal.identity
       };
       principal.accounts.forEach((account, subaccount) => {
@@ -161,6 +162,7 @@ function saveDb(newState){
       accounts : [],
       neurons : [],
       apps : [],
+      name : principal.name,
       identity : principal.identity
     };
     principal.accounts.forEach(account => {
@@ -360,6 +362,17 @@ function rootReducer(state = initDb(), action) {
       return saveDb({
         ...state,
         currentToken : action.payload.index ?? 0
+      });
+    case "principal/edit":
+      return saveDb({
+        ...state,
+        principals : state.principals.map((principal,i) => {
+          if (i === action.payload.index) {
+            return { ...principal, name : action.payload.name };
+          } else {
+            return principal;
+          }
+        }),
       });
     case "account/edit":
       return saveDb({


### PR DESCRIPTION
Adds the **naming** part of #166 — *"Could we also name these principals as well?"*

- Each principal gets an optional, **persisted `name`** (stored via the existing `saveDb`/`initDb`; a new `principal/edit` reducer case sets it). **Backward compatible** — older saved wallets just have no name until one is set.
- The **Select a Principal** switcher gets a pencil (rename) button per principal, reusing the existing `InputForm` dialog. When a name is set it's shown as the primary label (falling back to the principal id when unnamed).

Verified: build **and** the headless smoke test pass (the switcher is on the first screen, so smoke exercises it).

> **Stacked on #167** (the switcher-info PR) since both touch the same switcher block. Please merge #167 first; GitHub will then retarget this to `main` automatically. If you'd rather have them combined into one PR, say the word.