### PR TITLE
feat: show each principal's total ICP balance in the switcher

### DIFF
--- a/src/containers/Unlock.js
+++ b/src/containers/Unlock.js
@@ -16,6 +16,8 @@ import AllInclusiveIcon from '@material-ui/icons/AllInclusive';
 import InsertDriveFileIcon from '@material-ui/icons/InsertDriveFile';
 import TextField from '@material-ui/core/TextField';
 import {StoicIdentity} from '../ic/identity.js';
+import extjs from '../ic/extjs.js';
+import {LEDGER_CANISTER_ID} from '../ic/utils.js';
 import { useSelector, useDispatch } from 'react-redux'
 import ListItemAvatar from '@material-ui/core/ListItemAvatar';
 import Avatar from '@material-ui/core/Avatar';
@@ -33,6 +35,7 @@ function Unlock(props) {
   const identity = useSelector(state => (state.principals.length ? state.principals[currentPrincipal].identity : {}))
   const [open, setOpen] = React.useState(true);
   const [changeDialog, setChangeDialog] = React.useState(false);
+  const [balances, setBalances] = React.useState({});
   const [password, setPassword] = React.useState('');
   const dispatch = useDispatch()
   const [openFileSelector, fsobj] = useFilePicker({
@@ -66,6 +69,24 @@ function Unlock(props) {
       }
     });
   };
+  React.useEffect(() => {
+    if (!changeDialog) return;
+    let cancelled = false;
+    setBalances({});
+    const api = extjs.connect('https://icp0.io/');
+    principals.forEach(async (principal, i) => {
+      let sum = 0;
+      await Promise.all(principal.accounts.map(async (acc) => {
+        try {
+          const b = await api.token(LEDGER_CANISTER_ID, 'ledger').getBalance(acc.address, principal.identity.principal);
+          sum += Number(b);
+        } catch (e) {}
+      }));
+      if (!cancelled) setBalances(prev => ({...prev, [i]: sum / 1e8}));
+    });
+    return () => { cancelled = true; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [changeDialog]);
   const renamePrincipal = (index, name) => {
     dispatch({ type: 'principal/edit', payload : {index : index, name : (name || '').trim()}});
   };
@@ -139,6 +160,7 @@ function Unlock(props) {
                     <>
                       {identityTypes[principal.identity.type]} · {accountCount} account{accountCount === 1 ? '' : 's'}
                       {firstAccount ? <><br />{firstAccount.address.substr(0, 24) + '…'}</> : ''}
+                      <br />{balances[i] === undefined ? 'Loading balance…' : '≈ ' + balances[i].toFixed(4) + ' ICP'}
                     </>
                   } />
                 <ListItemSecondaryAction>


### PR DESCRIPTION
Completes #166 — adds each principal's **total ICP balance** to the switcher (the option chosen: live-fetch on open for accuracy).

- When the **Select a Principal** dialog opens, it fetches the ICP balance of **every account** under each principal and shows the **per-principal total**.
- Loads **progressively** — each principal shows `Loading balance…` until its total resolves, so a slow account doesn't block the others.
- Per-account fetch failures are ignored (contribute 0), so one bad account can't break the screen.

Live-fetched on open (no caching), so the figure is always current. The extra calls only happen when you actually open the switcher.

Verified: build **and** headless smoke test pass.

> **Stacked on #168 → #167.** Merge order: #167, then #168, then this. GitHub will retarget each to `main` as the one below it merges. Once all three land, #166 is fully addressed and can be closed.