### PR TITLE
revert: remove the receive QR code (breaks layout)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,6 @@
         "os-browserify": "^0.3.0",
         "path-browserify": "^1.0.1",
         "process": "^0.11.10",
-        "qrcode.react": "^3.1.0",
         "querystring-es3": "^0.2.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -18021,15 +18020,6 @@
         "teleport": ">=0.2.0"
       }
     },
-    "node_modules/qrcode.react": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-3.2.0.tgz",
-      "integrity": "sha512-YietHHltOHA4+l5na1srdaMx4sVSOjV9tamHs+mwiLWAMr6QVACRUw1Neax5CptFILcNoITctJY0Ipyn5enQ8g==",
-      "license": "ISC",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
     "node_modules/qs": {
       "version": "6.15.3",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
@@ -35990,11 +35980,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
       "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw=="
-    },
-    "qrcode.react": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-3.2.0.tgz",
-      "integrity": "sha512-YietHHltOHA4+l5na1srdaMx4sVSOjV9tamHs+mwiLWAMr6QVACRUw1Neax5CptFILcNoITctJY0Ipyn5enQ8g=="
     },
     "qs": {
       "version": "6.15.3",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "dotenv": "^17.4.2",
     "ethereum-blockies-base64": "^1.0.2",
     "json-bigint": "^1.0.0",
-    "qrcode.react": "^3.1.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-redux": "^7.2.4",

--- a/src/views/AccountDetail.js
+++ b/src/views/AccountDetail.js
@@ -20,7 +20,6 @@ import EvStationIcon from '@material-ui/icons/EvStation';
 import {useTheme} from '@material-ui/core/styles';
 import Tooltip from '@material-ui/core/Tooltip';
 import Blockie from '../components/Blockie';
-import {QRCodeCanvas} from 'qrcode.react';
 import SnackbarButton from '../components/SnackbarButton';
 import TokenCard from '../components/TokenCard';
 import NFTCard from '../components/NFTCard';
@@ -442,12 +441,6 @@ function AccountDetail(props) {
                 ) : (
                   ''
                 )}
-                <div style={{textAlign: 'center', margin: '15px 0'}}>
-                  <QRCodeCanvas value={account.address} size={128} includeMargin />
-                  <div style={{fontSize: '0.8em', color: '#888', marginTop: 5}}>
-                    Scan to receive ICP &amp; tokens
-                  </div>
-                </div>
               </>
             }
           />


### PR DESCRIPTION
The receive QR code added in #162 breaks the account-header layout, so this removes it for now.

- Removes the `QRCodeCanvas` block and its import from `AccountDetail.js`.
- Removes the `qrcode.react` dependency (pruned from the lockfile).

No other behaviour changes. If we want to bring it back later, a dedicated **Receive** dialog (QR + full address + copy) would avoid cramming it into the header.

Verified: `npm run build` passes on Node 20.
