### PR TITLE
feat: installable, offline-capable PWA

### DIFF
--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512">
+  <rect width="512" height="512" rx="96" fill="#003240"/>
+  <text x="50%" y="50%" dy=".35em" text-anchor="middle"
+        font-family="Helvetica, Arial, sans-serif" font-size="300" font-weight="700" fill="#00b894">S</text>
+</svg>

--- a/public/index.html
+++ b/public/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
+    <meta name="theme-color" content="#003240" />
     <meta property="og:title" content="Stoic Wallet" />
     <meta property="og:description" content="A non-custodial frontend wallet for the Internet Computer, by Toniq Labs." />
     <meta property="og:type" content="website" />
@@ -12,9 +12,9 @@
     <meta name="twitter:card" content="summary" />
     <meta
       name="description"
-      content="Web site created using create-react-app"
+      content="A non-custodial frontend wallet for the Internet Computer, by Toniq Labs."
     />
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,20 +1,15 @@
 {
   "short_name": "Stoic",
   "name": "Stoic Wallet by Toniq Labs",
+  "description": "A non-custodial frontend wallet for the Internet Computer.",
   "icons": [
-    {
-      "src": "favicon.ico",
-      "sizes": "64x64 32x32 24x24 16x16",
-      "type": "image/x-icon"
-    },
-    {
-      "src": "logo.png",
-      "type": "image/png",
-      "sizes": "340x100"
-    }
+    { "src": "favicon.ico", "sizes": "64x64 32x32 24x24 16x16", "type": "image/x-icon" },
+    { "src": "icon.svg", "type": "image/svg+xml", "sizes": "any", "purpose": "any maskable" }
   ],
   "start_url": ".",
+  "scope": "/",
   "display": "standalone",
-  "theme_color": "#000000",
-  "background_color": "#ffffff"
+  "orientation": "portrait",
+  "theme_color": "#003240",
+  "background_color": "#fafafa"
 }

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,0 +1,37 @@
+/* Stoic Wallet service worker — offline app shell + static asset caching.
+   Cross-origin (IC mainnet) requests always bypass the cache. */
+const CACHE = 'stoic-cache-v1';
+const APP_SHELL = ['/', '/index.html', '/manifest.json', '/logo.png', '/favicon.ico', '/icon.svg'];
+
+self.addEventListener('install', (e) => {
+  e.waitUntil(
+    caches.open(CACHE).then((c) => c.addAll(APP_SHELL).catch(() => {})).then(() => self.skipWaiting())
+  );
+});
+self.addEventListener('activate', (e) => {
+  e.waitUntil(
+    caches.keys()
+      .then((keys) => Promise.all(keys.filter((k) => k !== CACHE).map((k) => caches.delete(k))))
+      .then(() => self.clients.claim())
+  );
+});
+self.addEventListener('fetch', (e) => {
+  const req = e.request;
+  if (req.method !== 'GET') return;
+  const url = new URL(req.url);
+  if (url.origin !== self.location.origin) return; // never cache IC API / cross-origin
+  if (req.mode === 'navigate') {
+    e.respondWith(fetch(req).catch(() => caches.match('/index.html')));
+    return;
+  }
+  e.respondWith(
+    caches.match(req).then((cached) =>
+      cached ||
+      fetch(req).then((res) => {
+        const copy = res.clone();
+        caches.open(CACHE).then((c) => c.put(req, copy));
+        return res;
+      }).catch(() => cached)
+    )
+  );
+});

--- a/src/index.js
+++ b/src/index.js
@@ -390,6 +390,11 @@ if (params.get('stoicTunnel') !== null) {
     }
   }
 } else {
+  if ('serviceWorker' in navigator) {
+    window.addEventListener('load', () => {
+      navigator.serviceWorker.register('/service-worker.js').catch(() => {});
+    });
+  }
   const root = createRoot(document.querySelector('#root'));
   root.render(
     <Provider store={store}>


### PR DESCRIPTION
Makes Stoic a proper **PWA** — installable to a phone/desktop home screen and resilient offline.

- **Service worker** (`public/service-worker.js`): precaches the app shell and caches static assets (cache-first); navigations are network-first with an offline fallback to the cached shell. **IC mainnet / cross-origin requests always bypass the cache**, so balances/transactions are never stale.
- **Installable manifest**: brand `theme_color`, `scope`, portrait orientation, and a **scalable maskable icon** (`icon.svg`) so the install icon looks right on Android/desktop.
- **Registration** on `load` (main app only, not the popup transport).
- **Fixes a real bug**: `index.html` referenced `logo192.png`, which doesn't exist (404) — repointed to the existing `logo.png`; also replaced the CRA-placeholder meta description.

Verified: `npm run build` passes and the worker + icon are emitted to `build/`.
