### PR TITLE
feat: dark mode (persisted toolbar toggle)

### DIFF
--- a/src/ThemeModeProvider.js
+++ b/src/ThemeModeProvider.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import { ThemeProvider } from '@material-ui/core/styles';
+import { makeTheme } from './theme';
+
+export const ThemeModeContext = React.createContext({ mode: 'light', toggle: () => {} });
+
+// Holds the light/dark preference (persisted to localStorage) and supplies the
+// matching MUI theme to the whole app.
+export default function ThemeModeProvider({ children }) {
+  const [mode, setMode] = React.useState(() => {
+    try { return localStorage.getItem('stoic-theme') || 'light'; } catch (e) { return 'light'; }
+  });
+  const toggle = React.useCallback(() => {
+    setMode((m) => {
+      const next = m === 'light' ? 'dark' : 'light';
+      try { localStorage.setItem('stoic-theme', next); } catch (e) {}
+      return next;
+    });
+  }, []);
+  const theme = React.useMemo(() => makeTheme(mode), [mode]);
+  return (
+    <ThemeModeContext.Provider value={{ mode, toggle }}>
+      <ThemeProvider theme={theme}>{children}</ThemeProvider>
+    </ThemeModeContext.Provider>
+  );
+}

--- a/src/components/AccountDrawer.js
+++ b/src/components/AccountDrawer.js
@@ -54,7 +54,7 @@ export default function AccountDrawer(props) {
   
   const accountsList = (
     <div style={{marginTop:64, marginBottom: 100}}>
-      <div style={{width:drawerWidth-1, zIndex: 10, backgroundColor:'white', position:"fixed", top:0, textAlign:"center"}} className={classes.toolbar}>
+      <div style={{width:drawerWidth-1, zIndex: 10, backgroundColor: theme.palette.background.paper, position:"fixed", top:0, textAlign:"center"}} className={classes.toolbar}>
         {/*<span style={{display:'block', fontSize:'x-large',padding:'15px 0', textAlign:'center',fontWeight:'bold'}}>Stoic Wallet <span style={{fontSize:'small',fontWeight:'normal'}}>By Toniq Labs</span></span>*/}
         <img style={{maxHeight:'50px',marginTop:'5px'}} alt="Stoic Wallet by Toniq Labs" src="logo.png" />
       </div>
@@ -107,7 +107,7 @@ export default function AccountDrawer(props) {
           <ListItemText primary="Lock Wallet" />
         </ListItem> }
       </List>
-      <div style={{width: drawerWidth-1, zIndex: 10, backgroundColor:'white', position:"fixed", bottom:0, textAlign:'center'}} className={classes.toolbar}>
+      <div style={{width: drawerWidth-1, zIndex: 10, backgroundColor: theme.palette.background.paper, position:"fixed", bottom:0, textAlign:'center'}} className={classes.toolbar}>
         <span style={{position:'absolute', bottom:'10px', left:'0', right:'0'}}>Connected to Mainnet - v2.0.0</span>
       </div>
     </div>

--- a/src/containers/Wallet.js
+++ b/src/containers/Wallet.js
@@ -6,12 +6,15 @@ import IconButton from '@material-ui/core/IconButton';
 import MenuIcon from '@material-ui/icons/Menu';
 import AccountCircleIcon from '@material-ui/icons/AccountCircle';
 import VisibilityIcon from '@material-ui/icons/Visibility';
+import Brightness4Icon from '@material-ui/icons/Brightness4';
+import Brightness7Icon from '@material-ui/icons/Brightness7';
 import VisibilityOffIcon from '@material-ui/icons/VisibilityOff';
 import Toolbar from '@material-ui/core/Toolbar';
 import Typography from '@material-ui/core/Typography';
 
 import AccountDrawer from '../components/AccountDrawer';
 import {BalanceVisibilityContext} from '../balanceVisibility';
+import {ThemeModeContext} from '../ThemeModeProvider';
 
 import AccountDetail from '../views/AccountDetail';
 import AddressBook from '../views/AddressBook';
@@ -112,6 +115,7 @@ function Wallet(props) {
     props.remove();
   };
   const [hideBalances, setHideBalances] = React.useState(false);
+  const {mode, toggle} = React.useContext(ThemeModeContext);
   return (
     <div className={classes.root}>
       <CssBaseline />
@@ -130,6 +134,9 @@ function Wallet(props) {
             {toolbarTitle}
           </Typography>
           <div className={classes.toolbarButtons}>
+            <IconButton color="inherit" aria-label="Toggle dark mode" onClick={toggle}>
+              {mode === 'dark' ? <Brightness7Icon /> : <Brightness4Icon />}
+            </IconButton>
             <IconButton
               color="inherit"
               aria-label={hideBalances ? 'Show balances' : 'Hide balances'}

--- a/src/index.js
+++ b/src/index.js
@@ -2,14 +2,13 @@ import './polyfills';
 import React from 'react';
 import {createRoot} from 'react-dom/client';
 import CssBaseline from '@material-ui/core/CssBaseline';
-import { ThemeProvider } from '@material-ui/core/styles';
 import App from './App';
 import ErrorBoundary from './components/ErrorBoundary';
 import { Provider } from 'react-redux'
 import store from './store'
 import {StoicIdentity} from './ic/identity.js';
 import {principalToAccountIdentifier, LEDGER_CANISTER_ID} from './ic/utils.js';
-import theme from './theme';
+import ThemeModeProvider from './ThemeModeProvider';
 import '@fontsource/roboto';
 function injectPopupStyles() {
   if (!document.getElementById("popup-styles")) {
@@ -393,12 +392,12 @@ if (params.get('stoicTunnel') !== null) {
   const root = createRoot(document.querySelector('#root'));
   root.render(
     <Provider store={store}>
-      <ThemeProvider theme={theme}>
+      <ThemeModeProvider>
         <CssBaseline />
         <ErrorBoundary>
           <App />
         </ErrorBoundary>
-      </ThemeProvider>
+      </ThemeModeProvider>
     </Provider>,
   );      
 }

--- a/src/theme.js
+++ b/src/theme.js
@@ -1,48 +1,32 @@
 import { red } from '@material-ui/core/colors';
-import { createTheme  } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 
-// A custom theme for this app
-const theme = createTheme ({
-  palette: {
-    primary: {
-      main: '#003240',
-    },
-    secondary: {
-      main: '#00b894',
-    },
-    error: {
-      main: red.A400,
-    },
-    background: {
-      default: '#fafafa',
-    },
-  },
-  overrides: {
-    MuiCssBaseline: {
-      "@global": {
-        body: {
-          backgroundImage:
-            "url(./bg.png)"
-        }
-      }
-    },
-    MuiIconButton: {
-      label : {
-        color : "#00b894"
-      }
-    },
-    MuiAvatar: {
-      colorDefault: {
-        backgroundColor : '#00b894',
-        color : 'white'
+// Build the Stoic theme for a given mode ('light' | 'dark').
+export const makeTheme = (mode = 'light') => {
+  const isDark = mode === 'dark';
+  return createTheme({
+    palette: {
+      type: mode,
+      primary: { main: isDark ? '#00b894' : '#003240' },
+      secondary: { main: '#00b894' },
+      error: { main: red.A400 },
+      background: {
+        default: isDark ? '#0e1a1f' : '#fafafa',
+        paper: isDark ? '#13242b' : '#ffffff',
       },
     },
-    MuiListItemIcon: {
-      root: {
-        color : '#00b894'
+    overrides: {
+      MuiCssBaseline: {
+        '@global': {
+          body: isDark ? { backgroundImage: 'none' } : { backgroundImage: 'url(./bg.png)' },
+        },
       },
+      MuiIconButton: { label: { color: '#00b894' } },
+      MuiAvatar: { colorDefault: { backgroundColor: '#00b894', color: 'white' } },
+      MuiListItemIcon: { root: { color: '#00b894' } },
     },
-  },
-});
+  });
+};
 
+const theme = makeTheme('light');
 export default theme;


### PR DESCRIPTION
Adds a **light/dark mode** toggle — a staple of every modern wallet.

- A **sun/moon toggle** in the app bar switches themes instantly.
- The choice is **persisted** to `localStorage` and restored on next visit.
- Implemented via a `ThemeModeProvider` (+ context) that builds the matching MUI theme from a single `makeTheme(mode)` factory, so the whole app re-themes from one place.
- Dark mode uses dark surfaces and drops the light background image; the drawer's fixed header/footer now follow the theme's paper colour instead of hardcoded white.

Verified: build + headless smoke test pass.

> Initial dark-mode pass — core MUI surfaces adapt automatically. A couple of components still use bespoke brand colours (e.g. the selected token card); I can polish those in a follow-up if you want them tuned for dark.
