### PR TITLE
feat: auto-lock the wallet after inactivity

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -116,6 +116,26 @@ export default function App() {
     login();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentPrincipal, principals]);
+  // Auto-lock the wallet after a period of inactivity (security).
+  // Configurable via localStorage 'stoic-autolock' (minutes; 0 disables). Default 15.
+  React.useEffect(() => {
+    if (appState !== 2) return;
+    const minutes = parseInt(localStorage.getItem('stoic-autolock') || '15', 10);
+    if (!minutes || minutes <= 0) return;
+    let timer;
+    const reset = () => {
+      clearTimeout(timer);
+      timer = setTimeout(() => { logout(); }, minutes * 60 * 1000);
+    };
+    const events = ['mousemove', 'mousedown', 'keydown', 'touchstart', 'scroll'];
+    events.forEach((e) => window.addEventListener(e, reset, {passive: true}));
+    reset();
+    return () => {
+      clearTimeout(timer);
+      events.forEach((e) => window.removeEventListener(e, reset));
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [appState]);
 
   const loader = (l, t) => {
     setLoaderText(t);


### PR DESCRIPTION
Security hardening: an unlocked wallet now **locks itself after inactivity** (like banking apps and MetaMask's auto-lock).

- Mouse, keyboard, touch and scroll activity reset the idle timer.
- On timeout it calls the existing lock flow (`logout`), returning to the unlock screen.
- Duration is read from the `stoic-autolock` localStorage key (minutes; `0` disables); **defaults to 15 minutes**.
- Listeners are attached only while unlocked and cleaned up on lock/unmount.

A Settings dropdown can be wired to that key in a follow-up. Verified: `npm run build` passes.
