### PR TITLE
feat: responsive token & NFT card grids (mobile)

### DIFF
--- a/src/components/NFTCard.js
+++ b/src/components/NFTCard.js
@@ -30,7 +30,7 @@ function NFTCard(props) {
     props.onClick();
   };
   return (
-    <Grid style={styles.root} item xl={2} lg={3} md={4}>
+    <Grid style={styles.root} item xs={6} sm={4} md={4} lg={3} xl={2}>
       <Card onClick={handleClick} style={props.selected ? styles.selectedCard : styles.card }>
         <CardActionArea>
           <CardContent>

--- a/src/components/TokenCard.js
+++ b/src/components/TokenCard.js
@@ -61,7 +61,7 @@ function TokenCard(props) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.address]);
   return (
-    <Grid style={styles.root} item xl={2} lg={3} md={4}>
+    <Grid style={styles.root} item xs={6} sm={4} md={4} lg={3} xl={2}>
       <Card onClick={handleClick} style={props.selected ? styles.selectedCard : styles.card}>
         <CardActionArea>
           <CardContent>


### PR DESCRIPTION
The token and NFT cards declared only `md`/`lg`/`xl` Grid widths, so on phones (below the `md` breakpoint) each card spanned the full row — one huge card at a time.

Adds `xs={6}` and `sm={4}` so the cards lay out **two per row on phones** and **three on small tablets**, scaling up to the existing desktop widths. Part of a broader mobile-responsiveness pass.

Verified: `npm run build` passes.
