### PR TITLE
feat: offline status banner

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -7,6 +7,7 @@ import {StoicIdentity} from './ic/identity.js';
 import extjs from './ic/extjs.js';
 import AlertDialog from './components/AlertDialog';
 import ConfirmDialog from './components/ConfirmDialog';
+import OfflineBanner from './components/OfflineBanner';
 const Wallet = React.lazy(() => import('./containers/Wallet'));
 const Connect = React.lazy(() => import('./containers/Connect'));
 const Unlock = React.lazy(() => import('./containers/Unlock'));
@@ -171,6 +172,7 @@ export default function App() {
         buttonConfirm={confirmData.buttonConfirm}
         handler={confirmData.handler}
       />
+      <OfflineBanner />
     </>
   );
 }

--- a/src/components/OfflineBanner.js
+++ b/src/components/OfflineBanner.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import Snackbar from '@material-ui/core/Snackbar';
+import Alert from '@material-ui/lab/Alert';
+
+// Shows a persistent warning while the browser is offline.
+export default function OfflineBanner() {
+  const [offline, setOffline] = React.useState(typeof navigator !== 'undefined' && !navigator.onLine);
+  React.useEffect(() => {
+    const goOnline = () => setOffline(false);
+    const goOffline = () => setOffline(true);
+    window.addEventListener('online', goOnline);
+    window.addEventListener('offline', goOffline);
+    return () => {
+      window.removeEventListener('online', goOnline);
+      window.removeEventListener('offline', goOffline);
+    };
+  }, []);
+  return (
+    <Snackbar open={offline} anchorOrigin={{vertical: 'bottom', horizontal: 'center'}}>
+      <Alert severity="warning" variant="filled">
+        You're offline — balances and transactions may be out of date.
+      </Alert>
+    </Snackbar>
+  );
+}


### PR DESCRIPTION
Adds a persistent **offline warning** banner (bottom-center) that appears whenever the browser loses connectivity and disappears when it returns.

Because this is a wallet, knowing your balances/transactions might be stale matters — and it complements the new PWA offline support (#172). Uses the standard `online`/`offline` events; zero new dependencies.

Verified: `npm run build` passes.
