### PR TITLE
feat: 25/50/75% amount presets on the send form

### DIFF
--- a/src/components/SendForm.js
+++ b/src/components/SendForm.js
@@ -107,6 +107,10 @@ export default function SendForm(props) {
   const sendMax = () => {
     setAmount(balance - Number(fee))
   };
+  const setPct = (p) => {
+    const max = balance - Number(fee);
+    setAmount(max > 0 ? Math.round((max * p / 100) * 1e8) / 1e8 : 0);
+  };
   const handleClick = () => {
     setOpen(true);
   };
@@ -223,6 +227,9 @@ export default function SendForm(props) {
               ) : (
                 ''
               )}
+              <Button size="small" onClick={() => setPct(25)} color="primary">25%</Button>
+              <Button size="small" onClick={() => setPct(50)} color="primary">50%</Button>
+              <Button size="small" onClick={() => setPct(75)} color="primary">75%</Button>
               <Button size="small" variant="outlined" onClick={sendMax} color="primary">Max</Button>
               <DialogContentText
                 style={{fontSize: 'small', textAlign: 'center', marginTop: '20px'}}


### PR DESCRIPTION
Adds **25% / 50% / 75%** quick-fill buttons next to the existing **Max** on the send form — the percentage-preset pattern from MetaMask/Phantom/exchanges.

Each sets the amount to that fraction of the **spendable** balance (balance − fee), rounded to 8 decimals. Verified: `npm run build` passes.
