### PR TITLE
feat: back-to-top button for long lists

### DIFF
--- a/src/components/ScrollTop.js
+++ b/src/components/ScrollTop.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import Fab from '@material-ui/core/Fab';
+import Zoom from '@material-ui/core/Zoom';
+import useScrollTrigger from '@material-ui/core/useScrollTrigger';
+import KeyboardArrowUpIcon from '@material-ui/icons/KeyboardArrowUp';
+
+// A back-to-top button that fades in once the page is scrolled down.
+export default function ScrollTop() {
+  const trigger = useScrollTrigger({disableHysteresis: true, threshold: 200});
+  const handleClick = () => window.scrollTo({top: 0, behavior: 'smooth'});
+  return (
+    <Zoom in={trigger}>
+      <Fab
+        size="small"
+        color="primary"
+        aria-label="scroll back to top"
+        onClick={handleClick}
+        style={{position: 'fixed', bottom: 16, left: 16, zIndex: 1200}}
+      >
+        <KeyboardArrowUpIcon />
+      </Fab>
+    </Zoom>
+  );
+}

--- a/src/containers/Wallet.js
+++ b/src/containers/Wallet.js
@@ -11,6 +11,7 @@ import Toolbar from '@material-ui/core/Toolbar';
 import Typography from '@material-ui/core/Typography';
 
 import AccountDrawer from '../components/AccountDrawer';
+import ScrollTop from '../components/ScrollTop';
 import {BalanceVisibilityContext} from '../balanceVisibility';
 
 import AccountDetail from '../views/AccountDetail';
@@ -154,6 +155,7 @@ function Wallet(props) {
             {renderView(route)}
           </BalanceVisibilityContext.Provider>
       </main>
+      <ScrollTop />
     </div>
   );
 }


### PR DESCRIPTION
Adds a floating **back-to-top** button (bottom-left) that fades in once you scroll past ~200px and smooth-scrolls to the top.

Useful on phones with long token/NFT/transaction lists. Positioned opposite the send FABs to avoid overlap. Built with MUI's `useScrollTrigger` + `Zoom` — no new deps.

Verified: build + headless smoke test pass.
