### PR TITLE
feat: paste-address button on the send form

### DIFF
--- a/src/components/SendForm.js
+++ b/src/components/SendForm.js
@@ -107,6 +107,12 @@ export default function SendForm(props) {
   const sendMax = () => {
     setAmount(balance - Number(fee))
   };
+  const pasteAddress = async () => {
+    try {
+      const t = await navigator.clipboard.readText();
+      if (t) setTo(t.trim());
+    } catch (e) {}
+  };
   const handleClick = () => {
     setOpen(true);
   };
@@ -196,6 +202,7 @@ export default function SendForm(props) {
                   />
                 )}
               />
+              <Button size="small" onClick={pasteAddress} color="primary" style={{marginTop: 2}}>Paste address</Button>
 
               <TextField
                 style={{width: '49%', marginRight: '2%'}}


### PR DESCRIPTION
Adds a **Paste address** button under the recipient field on the send form, filling it from the clipboard.

Pasting a long IC address/principal on mobile is fiddly; one tap is much nicer. Uses `navigator.clipboard.readText()` and degrades silently where clipboard read isn't permitted. Verified: `npm run build` passes.
