### PR TITLE
feat: full-screen dialogs on mobile

### DIFF
--- a/src/components/SendForm.js
+++ b/src/components/SendForm.js
@@ -1,5 +1,7 @@
 /* global BigInt */
 import React from 'react';
+import useMediaQuery from '@material-ui/core/useMediaQuery';
+import {useTheme} from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
 import TextField from '@material-ui/core/TextField';
 import Dialog from '@material-ui/core/Dialog';
@@ -25,6 +27,8 @@ export default function SendForm(props) {
     state.principals.length ? state.principals[currentPrincipal].identity : {},
   );
   const [open, setOpen] = React.useState(false);
+  const _theme = useTheme();
+  const fullScreen = useMediaQuery(_theme.breakpoints.down('xs'));
   const [step, setStep] = React.useState(0);
   const [balance, setBalance] = React.useState(false);
 
@@ -157,7 +161,7 @@ export default function SendForm(props) {
   return (
     <>
       {React.cloneElement(props.children, {onClick: handleClick})}
-      <Dialog open={open} onClose={handleClose} maxWidth={'sm'} fullWidth>
+      <Dialog open={open} onClose={handleClose} maxWidth={'sm'} fullWidth fullScreen={fullScreen}>
         <DialogTitle id="form-dialog-title" style={{textAlign: 'center'}}>
           Send {props.data.name} Tokens ({props.data.symbol})
         </DialogTitle>

--- a/src/components/SendNFTForm.js
+++ b/src/components/SendNFTForm.js
@@ -1,5 +1,7 @@
 /* global BigInt */
 import React from 'react';
+import useMediaQuery from '@material-ui/core/useMediaQuery';
+import {useTheme} from '@material-ui/core/styles';
 import {validateAddress, validatePrincipal} from '../ic/utils.js';
 import Button from '@material-ui/core/Button';
 import TextField from '@material-ui/core/TextField';
@@ -24,6 +26,8 @@ export default function SendNFTForm(props) {
     state.principals.length ? state.principals[currentPrincipal].identity : {},
   );
   const [step, setStep] = React.useState(0);
+  const _theme = useTheme();
+  const fullScreen = useMediaQuery(_theme.breakpoints.down('xs'));
 
   const [to, setTo] = React.useState('');
   const [toOption, setToOption] = React.useState('');
@@ -104,7 +108,7 @@ export default function SendNFTForm(props) {
 
   return (
     <>
-      <Dialog open={props.open} onClose={handleClose} maxWidth={'sm'} fullWidth>
+      <Dialog open={props.open} onClose={handleClose} maxWidth={'sm'} fullWidth fullScreen={fullScreen}>
         <DialogTitle id="form-dialog-title" style={{textAlign: 'center'}}>
           Send NFT
         </DialogTitle>

--- a/src/components/TopupForm.js
+++ b/src/components/TopupForm.js
@@ -1,5 +1,7 @@
 /* global BigInt */
 import React from 'react';
+import useMediaQuery from '@material-ui/core/useMediaQuery';
+import {useTheme} from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
 import TextField from '@material-ui/core/TextField';
 import Dialog from '@material-ui/core/Dialog';
@@ -20,6 +22,8 @@ export default function TopupForm(props) {
     state.principals.length ? state.principals[currentPrincipal].identity : {},
   );
   const [open, setOpen] = React.useState(false);
+  const _theme = useTheme();
+  const fullScreen = useMediaQuery(_theme.breakpoints.down('xs'));
   const [step, setStep] = React.useState(0);
   const [balance, setBalance] = React.useState(false);
   const [rate, setRate] = React.useState(0);
@@ -107,7 +111,7 @@ export default function TopupForm(props) {
   return (
     <>
       {React.cloneElement(props.children, {onClick: handleClick})}
-      <Dialog open={open} onClose={handleClose} maxWidth={'sm'} fullWidth>
+      <Dialog open={open} onClose={handleClose} maxWidth={'sm'} fullWidth fullScreen={fullScreen}>
         <DialogTitle id="form-dialog-title" style={{textAlign: 'center'}}>
           Top-up your canister
         </DialogTitle>


### PR DESCRIPTION
On phones (xs breakpoint), the **Send**, **Topup** and **Send-NFT** dialogs now open **full-screen** instead of a cramped centred modal — the standard mobile pattern, giving the forms room and larger tap targets.

Uses MUI `useMediaQuery(theme.breakpoints.down('xs'))` + the Dialog `fullScreen` prop; desktop is unchanged. Part of the mobile-responsiveness pass. Verified: `npm run build` passes.
