### PR TITLE
feat: live recipient validation on the send form

### DIFF
--- a/src/components/SendForm.js
+++ b/src/components/SendForm.js
@@ -190,6 +190,8 @@ export default function SendForm(props) {
                     label="Address of the Recipient"
                     type="text"
                     fullWidth
+                    error={!!to && !validateAddress(to) && !validatePrincipal(to)}
+                    helperText={!!to && !validateAddress(to) && !validatePrincipal(to) ? 'Not a valid address or principal' : ''}
                     InputLabelProps={{
                       shrink: true,
                     }}


### PR DESCRIPTION
The send form only validated the recipient at the **Review** step. Now the field gives **live feedback** — it turns red with "Not a valid address or principal" as soon as you type something that isn't a valid account address or principal, and clears once it's valid.

Reuses the existing `validateAddress` / `validatePrincipal` helpers; catches typos before you commit to a transfer. Verified: `npm run build` passes.
