### PR TITLE
feat: PWA install prompt

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,6 +6,7 @@ import {makeStyles} from '@material-ui/core/styles';
 import {StoicIdentity} from './ic/identity.js';
 import extjs from './ic/extjs.js';
 import AlertDialog from './components/AlertDialog';
+import InstallPrompt from './components/InstallPrompt';
 import ConfirmDialog from './components/ConfirmDialog';
 const Wallet = React.lazy(() => import('./containers/Wallet'));
 const Connect = React.lazy(() => import('./containers/Connect'));
@@ -152,6 +153,7 @@ export default function App() {
         ''
       )}
       </Suspense>
+      <InstallPrompt />
       <Backdrop className={classes.backdrop} open={loaderOpen} role="status" aria-live="polite">
         <CircularProgress color="inherit" />
         <h2 style={{position: 'absolute', marginTop: '120px'}}>{loaderText ?? 'Loading...'}</h2>

--- a/src/components/InstallPrompt.js
+++ b/src/components/InstallPrompt.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import Snackbar from '@material-ui/core/Snackbar';
+import Button from '@material-ui/core/Button';
+
+// Offers an "Install" action when the browser fires beforeinstallprompt (PWA).
+export default function InstallPrompt() {
+  const [deferred, setDeferred] = React.useState(null);
+  const [open, setOpen] = React.useState(false);
+  React.useEffect(() => {
+    const handler = (e) => {
+      e.preventDefault();
+      setDeferred(e);
+      setOpen(true);
+    };
+    window.addEventListener('beforeinstallprompt', handler);
+    return () => window.removeEventListener('beforeinstallprompt', handler);
+  }, []);
+  const install = async () => {
+    setOpen(false);
+    if (!deferred) return;
+    deferred.prompt();
+    try { await deferred.userChoice; } catch (e) {}
+    setDeferred(null);
+  };
+  return (
+    <Snackbar
+      open={open}
+      anchorOrigin={{vertical: 'bottom', horizontal: 'center'}}
+      message="Install Stoic Wallet for quick access"
+      action={
+        <>
+          <Button color="secondary" size="small" onClick={install}>Install</Button>
+          <Button color="inherit" size="small" onClick={() => setOpen(false)}>Dismiss</Button>
+        </>
+      }
+    />
+  );
+}


### PR DESCRIPTION
Adds an **"Install" prompt**: when the browser signals the app is installable (`beforeinstallprompt`), a snackbar offers **Install** / **Dismiss** so users can add Stoic to their home screen or desktop with one tap.

Complements the PWA service worker + manifest (#172). No new deps; the event simply never fires on unsupported browsers (graceful). Verified: `npm run build` passes.
