### PR TITLE
feat: welcome/trust message on connect screen

### DIFF
--- a/src/containers/Connect.js
+++ b/src/containers/Connect.js
@@ -71,6 +71,10 @@ function Connect(props) {
       <Dialog hideBackdrop maxWidth={'sm'} fullWidth open={open}>
         <DialogTitle id="form-dialog-title" style={{textAlign:'center'}}><img style={{maxHeight:'80px',marginTop:'5px'}} alt="Stoic Wallet by Toniq Labs" src="logo.png" /></DialogTitle>
         <DialogContent>
+          <p style={{textAlign: 'center', marginTop: 0, color: '#777', fontSize: '0.95em'}}>
+            A non-custodial wallet for the Internet Computer.<br />
+            Your keys are encrypted and never leave your device.
+          </p>
           <ConnectList handler={handleClick} />
         </DialogContent>
       </Dialog>


### PR DESCRIPTION
First-time users land on a bare logo + list of connect options. This adds a short, reassuring welcome line — *"A non-custodial wallet for the Internet Computer. Your keys are encrypted and never leave your device."* — to set context and build trust before someone creates/imports a wallet.

Verified: `npm run build` passes.
