### PR TITLE
feat: live recipient validation on NFT transfer form

### DIFF
--- a/src/components/SendNFTForm.js
+++ b/src/components/SendNFTForm.js
@@ -144,6 +144,8 @@ export default function SendNFTForm(props) {
                     label="Address of the Recipient"
                     type="text"
                     fullWidth
+                    error={!!to && !validateAddress(to) && !validatePrincipal(to)}
+                    helperText={!!to && !validateAddress(to) && !validatePrincipal(to) ? 'Not a valid address or principal' : ''}
                     InputLabelProps={{
                       shrink: true,
                     }}


### PR DESCRIPTION
Mirrors the send-form live validation for **NFT transfers**: the recipient field now turns red with "Not a valid address or principal" as you type an invalid value, instead of only erroring at the review step.

NFT transfers are irreversible, so catching a bad recipient early matters. Reuses the existing validators already imported in the form. Verified: `npm run build` passes.
