### PR TITLE
feat: About section in Settings

### DIFF
--- a/src/views/Settings.js
+++ b/src/views/Settings.js
@@ -238,6 +238,19 @@ function Settings(props) {
             primary="Remove all wallets from this device"/>
         </ListItem>
       </List>
+      <Divider />
+      <List component="nav" subheader={<ListSubheader>About</ListSubheader>}>
+        <ListItem>
+          <ListItemText primary="Stoic Wallet" secondary="Version 2.0.0 · Connected to Mainnet" />
+        </ListItem>
+        <ListItem button component="a" href="https://github.com/Toniq-Labs/stoic-wallet" target="_blank" rel="noopener noreferrer">
+          <ListItemText primary="Source code" secondary="github.com/Toniq-Labs/stoic-wallet" />
+          <LaunchIcon style={{color: '#00b894'}} />
+        </ListItem>
+        <ListItem button component="a" href="mailto:support@toniqlabs.com">
+          <ListItemText primary="Support" secondary="support@toniqlabs.com" />
+        </ListItem>
+      </List>
       <WalletDialog alert={props.alert} initialRoute={initialRoute} cancel={cancel} submit={submit} />
     </>
   );


### PR DESCRIPTION
Adds an **About** section at the bottom of Settings:

- App **version** + network ("Version 2.0.0 · Connected to Mainnet").
- Link to the **source code** (GitHub).
- **Support** email link.

Standard wallet "About" affordance; helps with support/bug reports. Verified: `npm run build` passes.
