### PR TITLE
feat: remember the last-active section

### DIFF
--- a/src/containers/Wallet.js
+++ b/src/containers/Wallet.js
@@ -77,7 +77,12 @@ const useStyles = makeStyles((theme) => ({
 function Wallet(props) {
   const classes = useStyles();
   const [mobileOpen, setMobileOpen] = React.useState(false);
-  const [route, setRoute] = React.useState('accountDetail');
+  const [route, setRoute] = React.useState(() => {
+    try {
+      const saved = localStorage.getItem('stoic-route');
+      return saved && routes[saved] ? saved : 'accountDetail';
+    } catch (e) { return 'accountDetail'; }
+  });
   const [toolbarTitle, setToolbarTitle] = React.useState(routes[route].title);
   const dispatch = useDispatch()
   
@@ -102,6 +107,7 @@ function Wallet(props) {
   const changeRoute = (r, i) => {
     setToolbarTitle(routes[r].title);
     setRoute(r);
+    try { localStorage.setItem('stoic-route', r); } catch (e) {}
     if (typeof i !== 'undefined') dispatch({ type: 'currentAccount', payload: {index:i}});
   };
   


### PR DESCRIPTION
The wallet always reopened on **Accounts**, even if you were last in Neurons / Applications / Address Book / Settings.

This persists the active section to `localStorage` and restores it on next load (validated against known routes, falling back to Accounts). The current account/principal were already persisted, so this completes "reopen where you left off."

Verified: build + headless smoke test pass.
