### PR TITLE
feat: re-land the Receive dialog (lost in #171 ghost-merge)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "os-browserify": "^0.3.0",
         "path-browserify": "^1.0.1",
         "process": "^0.11.10",
+        "qrcode.react": "^3.1.0",
         "querystring-es3": "^0.2.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -18020,6 +18021,15 @@
         "teleport": ">=0.2.0"
       }
     },
+    "node_modules/qrcode.react": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-3.2.0.tgz",
+      "integrity": "sha512-YietHHltOHA4+l5na1srdaMx4sVSOjV9tamHs+mwiLWAMr6QVACRUw1Neax5CptFILcNoITctJY0Ipyn5enQ8g==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/qs": {
       "version": "6.15.3",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
@@ -35980,6 +35990,11 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
       "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw=="
+    },
+    "qrcode.react": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-3.2.0.tgz",
+      "integrity": "sha512-YietHHltOHA4+l5na1srdaMx4sVSOjV9tamHs+mwiLWAMr6QVACRUw1Neax5CptFILcNoITctJY0Ipyn5enQ8g=="
     },
     "qs": {
       "version": "6.15.3",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "dotenv": "^17.4.2",
     "ethereum-blockies-base64": "^1.0.2",
     "json-bigint": "^1.0.0",
+    "qrcode.react": "^3.1.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-redux": "^7.2.4",

--- a/src/components/ReceiveDialog.js
+++ b/src/components/ReceiveDialog.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import Dialog from '@material-ui/core/Dialog';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogActions from '@material-ui/core/DialogActions';
+import Button from '@material-ui/core/Button';
+import Typography from '@material-ui/core/Typography';
+import IconButton from '@material-ui/core/IconButton';
+import FileCopyIcon from '@material-ui/icons/FileCopy';
+import {QRCodeCanvas} from 'qrcode.react';
+import SnackbarButton from './SnackbarButton';
+import {clipboardCopy} from '../utils';
+
+// A dedicated "Receive" dialog: scannable QR of the account address, the full
+// address, and a copy button. Wraps its child element and opens on click.
+export default function ReceiveDialog(props) {
+  const [open, setOpen] = React.useState(false);
+  const handleOpen = () => setOpen(true);
+  const handleClose = () => setOpen(false);
+  return (
+    <>
+      {React.cloneElement(props.children, {onClick: handleOpen})}
+      <Dialog open={open} onClose={handleClose} maxWidth="xs" fullWidth>
+        <DialogTitle style={{textAlign: 'center'}}>Receive</DialogTitle>
+        <DialogContent style={{textAlign: 'center'}}>
+          <div style={{padding: '8px 0'}}>
+            <QRCodeCanvas value={props.address ?? ''} size={200} includeMargin />
+          </div>
+          <Typography variant="body2" color="textSecondary">
+            Send ICP and tokens to this address
+          </Typography>
+          <div
+            style={{
+              wordBreak: 'break-all',
+              fontSize: '0.85em',
+              marginTop: 12,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: 4,
+            }}
+          >
+            <span>{props.address}</span>
+            <SnackbarButton
+              message="Address Copied"
+              anchorOrigin={{vertical: 'bottom', horizontal: 'center'}}
+              onClick={() => clipboardCopy(props.address)}
+            >
+              <IconButton size="small" aria-label="copy address">
+                <FileCopyIcon style={{fontSize: 18}} />
+              </IconButton>
+            </SnackbarButton>
+          </div>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleClose} color="primary">Close</Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+}

--- a/src/views/AccountDetail.js
+++ b/src/views/AccountDetail.js
@@ -12,6 +12,7 @@ import IconButton from '@material-ui/core/IconButton';
 import Avatar from '@material-ui/core/Avatar';
 import LaunchIcon from '@material-ui/icons/Launch';
 import SendIcon from '@material-ui/icons/Send';
+import CropFreeIcon from '@material-ui/icons/CropFree';
 import FileCopyIcon from '@material-ui/icons/FileCopy';
 import EditIcon from '@material-ui/icons/Edit';
 import Fab from '@material-ui/core/Fab';
@@ -24,6 +25,7 @@ import SnackbarButton from '../components/SnackbarButton';
 import TokenCard from '../components/TokenCard';
 import NFTCard from '../components/NFTCard';
 import SendForm from '../components/SendForm';
+import ReceiveDialog from '../components/ReceiveDialog';
 import TopupForm from '../components/TopupForm';
 import Transactions from '../components/Transactions';
 import NFTList from '../components/NFTList';
@@ -406,6 +408,11 @@ function AccountDetail(props) {
                       <FileCopyIcon style={{fontSize: 18}} />
                     </IconButton>
                   </SnackbarButton>
+                  <ReceiveDialog address={account.address}>
+                    <IconButton style={{top: '-10px'}} size="small" edge="end" aria-label="receive">
+                      <CropFreeIcon style={{fontSize: 18}} />
+                    </IconButton>
+                  </ReceiveDialog>
                 </div>
                 {currentAccount === 0 ? (
                   <div style={{fontSize: '0.9em'}}>


### PR DESCRIPTION
**#171 ghost-merged** (it was stacked on #170 and squash-merged), so the proper Receive dialog never actually landed — and since #170 *did* remove the inline header QR, the wallet currently has **no receive-QR feature at all**.

This re-lands it cleanly off current `main`:
- New **`ReceiveDialog`** component (centred QR of the account address + full address + copy button).
- Opened by a **scan-frame icon** next to the address in the account header.
- Restores the `qrcode.react` dependency.

Verified: build + headless smoke test pass.
