### PR TITLE
fix: send/topup amount & fee precision bugs

### DIFF
--- a/src/components/SendForm.js
+++ b/src/components/SendForm.js
@@ -55,7 +55,7 @@ export default function SendForm(props) {
     if (isNaN(amount)) return error('Please enter a valid amount to send');
     if (Number(amount) <= 0) return error('Please enter an amount greater than 0');
     if (isNaN(fee)) return error('Please enter a valid fee to use');
-    if (fee !== minFee) return error('The fee must be ' + minFee);
+    if (Number(fee) !== Number(minFee)) return error('The fee must be ' + minFee);
     switch (props.data.symbol) {
       case 'HZLD':
         if (!validatePrincipal(to)) return error('Please enter a valid principal to send to');

--- a/src/components/TopupForm.js
+++ b/src/components/TopupForm.js
@@ -51,8 +51,8 @@ export default function TopupForm(props) {
     var _from_principal = identity.principal;
     var _from_sa = currentAccount;
     var _canister = to;
-    var _amount = BigInt(amount * 10 ** 8);
-    var _fee = BigInt(0.0001 * 10 ** 8);
+    var _amount = BigInt(Math.round(Number(amount) * 10 ** 8));
+    var _fee = BigInt(10000);
     //Load signing ID
     const id = StoicIdentity.getIdentity(identity.principal);
     if (!id) return error('Something wrong with your wallet, try logging in again');


### PR DESCRIPTION
Two real, user-blocking money-math bugs found in the audit.

- **Topup throws on fractional ICP.** TopupForm did BigInt(amount * 10 ** 8); 0.1 * 1e8 === 10000000.000000002, and BigInt() of a non-integer throws, aborting the top-up. Now rounds (like SendForm) and uses the exact ledger fee BigInt(10000).
- **Send fee check compared string vs number.** The fee field stores a string, so fee !== minFee (Number) always failed after editing, falsely rejecting valid sends. Now compares numerically.

Touches no unit-tested code. Build + headless smoke pass. (Note: 2 ErrorBoundary tests were already failing on main since #186 — unrelated; fixed in #197.)