### PR TITLE
test: fix ErrorBoundary test (failing on main since #186)

### DIFF
--- a/src/components/ErrorBoundary.test.js
+++ b/src/components/ErrorBoundary.test.js
@@ -1,11 +1,16 @@
 import ErrorBoundary from './ErrorBoundary';
 
 describe('ErrorBoundary', () => {
-  it('flags hasError from getDerivedStateFromError', () => {
-    expect(ErrorBoundary.getDerivedStateFromError(new Error('boom'))).toEqual({hasError: true});
+  it('flags hasError and captures the error from getDerivedStateFromError', () => {
+    const err = new Error('boom');
+    const next = ErrorBoundary.getDerivedStateFromError(err);
+    expect(next.hasError).toBe(true);
+    expect(next.error).toBe(err);
   });
   it('initializes without an error state', () => {
     const eb = new ErrorBoundary({});
-    expect(eb.state).toEqual({hasError: false});
+    expect(eb.state.hasError).toBe(false);
+    expect(eb.state.error).toBeNull();
+    expect(eb.state.showDetails).toBe(false);
   });
 });


### PR DESCRIPTION
The test suite has **2 failing tests on `main`**: PR #186 (richer error screen) added `error`/`showDetails` to `ErrorBoundary`'s state and made `getDerivedStateFromError` capture the error, but `ErrorBoundary.test.js` still asserted the old exact state shape (`{hasError: false}` / `{hasError: true}`) — a regression I missed.

This updates the test to **field-level assertions** (also verifying the error is captured), which match the current component and won't break on future state additions. Restores a green suite.
