### PR TITLE
fix: balance-fetch reliability + transfer memo precision

### DIFF
--- a/src/components/TokenCard.js
+++ b/src/components/TokenCard.js
@@ -41,7 +41,6 @@ const styles = {
     marginBottom: 12,
   },
 };
-var intervalId = 0;
 const api = extjs.connect('https://icp0.io/');
 function TokenCard(props) {
   const [balance, setBalance] = React.useState(false);
@@ -66,14 +65,13 @@ function TokenCard(props) {
       .getBalance(props.address, identity.principal)
       .then(b => {
         setBalance(Number(b) / 10 ** props.data.decimals);
-      });
+      })
+      .catch(() => {});
   };
   React.useEffect(() => {
     updateBalance();
-    intervalId = setInterval(() => updateBalance(), 10000);
-    return () => {
-      clearInterval(intervalId);
-    };
+    const id = setInterval(() => updateBalance(), 10000);
+    return () => clearInterval(id);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
   React.useEffect(() => {

--- a/src/ic/extjs.js
+++ b/src/ic/extjs.js
@@ -295,14 +295,16 @@ class ExtConnection {
         switch (this._standard) {
           case "ledger":
             let res;
-            while(true){
+            let attempts = 0;
+            while (true) {
               try {
                 res = await api.account_balance_dfx({
                   account: address,
                 });
                 break;
-              } catch(e) {
-                console.error(e, "trying again in 1000ms");
+              } catch (e) {
+                if (++attempts >= 5) throw e;
+                console.error(e, "retrying ledger balance in 2000ms (" + attempts + "/5)");
                 await new Promise(r => setTimeout(r, 2000));
               }
             }
@@ -368,7 +370,7 @@ class ExtConnection {
                 to: toAddress,
                 amount: {e8s: amount},
                 fee: {e8s: fee},
-                memo: memo ? Number(BigInt(memo)) : 0,
+                memo: memo ? BigInt(memo) : 0,
                 created_at_time: [],
               };
               const bh = await api.send_dfx(args);


### PR DESCRIPTION
Three IC-interaction reliability bugs from the audit.

- **Leaked balance-poll intervals.** `TokenCard` kept its `setInterval` id in a **module-global** shared by every card; with N cards only the last id was tracked, so cleanup cleared the wrong timer and the rest leaked forever, polling the IC every 10s for the whole session. Each card now owns/clears its own interval; balance errors are caught.
- **Unbounded ledger retry.** `extjs` `getBalance` retried `account_balance_dfx` in a `while(true)` with no cap — a persistent error hung the promise and stacked loops. Now caps at 5 attempts then rejects.
- **Transfer memo precision.** `Number(BigInt(memo))` truncates `nat64` memos above 2^53; kept as a `BigInt`.

Verified: build + headless smoke pass; 16/18 unit tests (the 2 ErrorBoundary failures are pre-existing on `main` since #186 — unrelated, fixed in #197).
