### PR TITLE
fix: error-handling & validation gaps in neuron / address-book forms

### DIFF
--- a/src/components/NeuronForm.js
+++ b/src/components/NeuronForm.js
@@ -37,6 +37,7 @@ export default function NeuronForm(props) {
   const [subaccount, setSubaccount] = React.useState(0);
 
   React.useEffect(() => {
+    let cancelled = false;
     if (subaccount !== false) {
       api
         .token()
@@ -45,9 +46,11 @@ export default function NeuronForm(props) {
           identity.principal,
         )
         .then(b => {
-          setBalance(Number(b) / 10 ** 8);
-        });
+          if (!cancelled) setBalance(Number(b) / 10 ** 8);
+        })
+        .catch(() => {});
     }
+    return () => { cancelled = true; };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [subaccount]);
 

--- a/src/components/TopupNeuronForm.js
+++ b/src/components/TopupNeuronForm.js
@@ -30,6 +30,7 @@ export default function NeuronDelayForm(props) {
   const [balance, setBalance] = React.useState(false);
 
   React.useEffect(() => {
+    let cancelled = false;
     if (subaccount !== false) {
       api
         .token()
@@ -38,9 +39,11 @@ export default function NeuronDelayForm(props) {
           identity.principal,
         )
         .then(b => {
-          setBalance(Number(b) / 10 ** 8);
-        });
+          if (!cancelled) setBalance(Number(b) / 10 ** 8);
+        })
+        .catch(() => {});
     }
+    return () => { cancelled = true; };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [subaccount, props.open]);
 

--- a/src/views/AddressBook.js
+++ b/src/views/AddressBook.js
@@ -25,6 +25,9 @@ function AddressBook(props) {
   const dispatch = useDispatch()
   
   const editAddress = (name, address, index) => {
+    if (!name) return error("Please enter a valid contact name");
+    if (name.length > 30) return error("Max length or contact names is 30 characters");
+    if (!validateAddress(address) && !validatePrincipal(address)) return error("Please enter a valid address or principal");
     dispatch({ type: 'addresses/edit', payload: {
       index : index,
       name : name,


### PR DESCRIPTION
Additive hardening for the lower-traffic forms flagged in the audit (no behaviour change on the happy path).

- **AddressBook `editAddress`** performed **no validation** (unlike `addAddress`), so editing a contact could save an empty name or an invalid address/principal. Now applies the same name/length/address checks.
- **NeuronForm** & **TopupNeuronForm** balance `useEffect`s had no `.catch` (a failed `getBalance` was an unhandled rejection) and could `setState` after unmount. Added a `cancelled` guard + `.catch`.

Verified: build + headless smoke pass (16/18 unit tests; the 2 ErrorBoundary failures are pre-existing on `main`, fixed in #197).
