### PR TITLE
ui: drawer copy removal + dark-mode header icons & logo

### DIFF
--- a/src/components/AccountDrawer.js
+++ b/src/components/AccountDrawer.js
@@ -17,11 +17,6 @@ import { makeStyles, useTheme } from '@material-ui/core/styles';
 import { useSelector, useDispatch } from 'react-redux'
 
 import Blockie from '../components/Blockie';
-import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction';
-import IconButton from '@material-ui/core/IconButton';
-import FileCopyIcon from '@material-ui/icons/FileCopy';
-import SnackbarButton from '../components/SnackbarButton';
-import {clipboardCopy} from '../utils';
 
 const drawerWidth = 300;
 
@@ -61,7 +56,7 @@ export default function AccountDrawer(props) {
     <div style={{marginTop:64, marginBottom: 100}}>
       <div style={{width:drawerWidth-1, zIndex: 10, backgroundColor: theme.palette.background.paper, position:"fixed", top:0, textAlign:"center"}} className={classes.toolbar}>
         {/*<span style={{display:'block', fontSize:'x-large',padding:'15px 0', textAlign:'center',fontWeight:'bold'}}>Stoic Wallet <span style={{fontSize:'small',fontWeight:'normal'}}>By Toniq Labs</span></span>*/}
-        <img style={{maxHeight:'50px',marginTop:'5px'}} alt="Stoic Wallet by Toniq Labs" src="logo.png" />
+        <img style={{maxHeight:'50px',marginTop:'5px', ...(theme.palette.type === 'dark' ? {filter: 'brightness(0) invert(1)'} : {})}} alt="Stoic Wallet by Toniq Labs" src="logo.png" />
       </div>
       <Divider />
       <List>
@@ -79,17 +74,6 @@ export default function AccountDrawer(props) {
                   secondaryTypographyProps={{noWrap:true}} 
                   primary={account.name}
                   secondary={account.address} />
-                <ListItemSecondaryAction>
-                  <SnackbarButton
-                    message="Address Copied"
-                    anchorOrigin={{vertical: 'bottom', horizontal: 'left'}}
-                    onClick={() => clipboardCopy(account.address)}
-                  >
-                    <IconButton edge="end" size="small" aria-label="copy address">
-                      <FileCopyIcon style={{fontSize: 18}} />
-                    </IconButton>
-                  </SnackbarButton>
-                </ListItemSecondaryAction>
               </ListItem>
             </div>
           )

--- a/src/containers/Connect.js
+++ b/src/containers/Connect.js
@@ -6,8 +6,10 @@ import ConnectList from '../components/ConnectList';
 import WalletDialog from '../components/WalletDialog';
 import {StoicIdentity} from '../ic/identity.js';
 import {  useDispatch } from 'react-redux'
+import {useTheme} from '@material-ui/core/styles';
 
 function Connect(props) {
+  const theme = useTheme();
   const [open, setOpen] = React.useState(true);
   const [initialRoute, setInitialRoute] = React.useState('');
   const dispatch = useDispatch()
@@ -69,7 +71,7 @@ function Connect(props) {
   return (
     <>
       <Dialog hideBackdrop maxWidth={'sm'} fullWidth open={open}>
-        <DialogTitle id="form-dialog-title" style={{textAlign:'center'}}><img style={{maxHeight:'80px',marginTop:'5px'}} alt="Stoic Wallet by Toniq Labs" src="logo.png" /></DialogTitle>
+        <DialogTitle id="form-dialog-title" style={{textAlign:'center'}}><img style={{maxHeight:'80px',marginTop:'5px', ...(theme.palette.type === 'dark' ? {filter: 'brightness(0) invert(1)'} : {})}} alt="Stoic Wallet by Toniq Labs" src="logo.png" /></DialogTitle>
         <DialogContent>
           <p style={{textAlign: 'center', marginTop: 0, color: '#777', fontSize: '0.95em'}}>
             A non-custodial wallet for the Internet Computer.<br />

--- a/src/containers/Wallet.js
+++ b/src/containers/Wallet.js
@@ -126,7 +126,7 @@ function Wallet(props) {
   return (
     <div className={classes.root}>
       <CssBaseline />
-      <AppBar position="fixed" className={classes.appBar}>
+      <AppBar position="fixed" className={classes.appBar} style={mode === 'dark' ? {backgroundColor: '#13242b'} : undefined}>
         <Toolbar>
           <IconButton
             color="inherit"


### PR DESCRIPTION
Addresses several pieces of UI feedback:

- **Removed the copy button** on each account row in the left drawer.
- **Dark mode header icons** were green on the green/primary app-bar (invisible) — the app-bar now uses a dark surface in dark mode so the icons show.
- **Dark-mode logo**: the logo is dark and vanished on dark backgrounds — it is now inverted to a light version in dark mode (drawer + connect screen).

Verified: build + headless smoke pass.