### PR TITLE
ui: move Receive icon to the right; Preferences below Other Principals

### DIFF
--- a/src/views/AccountDetail.js
+++ b/src/views/AccountDetail.js
@@ -374,6 +374,13 @@ function AccountDetail(props) {
                       <LaunchIcon />
                     </IconButton>
                   </Tooltip>
+                  <ReceiveDialog address={account.address}>
+                    <Tooltip title="Receive (show QR)">
+                      <IconButton edge="end" aria-label="receive">
+                        <CropFreeIcon />
+                      </IconButton>
+                    </Tooltip>
+                  </ReceiveDialog>
                 </span>
               </>
             }
@@ -408,11 +415,6 @@ function AccountDetail(props) {
                       <FileCopyIcon style={{fontSize: 18}} />
                     </IconButton>
                   </SnackbarButton>
-                  <ReceiveDialog address={account.address}>
-                    <IconButton style={{top: '-10px'}} size="small" edge="end" aria-label="receive">
-                      <CropFreeIcon style={{fontSize: 18}} />
-                    </IconButton>
-                  </ReceiveDialog>
                 </div>
                 {currentAccount === 0 ? (
                   <div style={{fontSize: '0.9em'}}>

--- a/src/views/Settings.js
+++ b/src/views/Settings.js
@@ -192,31 +192,6 @@ function Settings(props) {
         </ListItem>
       </List>
       <Divider />
-      <List component="nav" subheader={<ListSubheader>Preferences</ListSubheader>}>
-        <ListItem>
-          <ListItemText primary="Auto-lock" secondary="Lock the wallet after this much inactivity" />
-          <ListItemSecondaryAction>
-            <FormControl size="small" variant="outlined" style={{minWidth: 130}}>
-              <Select
-                value={autoLock}
-                onChange={(e) => {
-                  setAutoLock(e.target.value);
-                  try { localStorage.setItem('stoic-autolock', String(e.target.value)); } catch (err) {}
-                }}
-                inputProps={{'aria-label': 'Auto-lock timeout'}}
-              >
-                <MenuItem value={0}>Never</MenuItem>
-                <MenuItem value={1}>1 minute</MenuItem>
-                <MenuItem value={5}>5 minutes</MenuItem>
-                <MenuItem value={15}>15 minutes</MenuItem>
-                <MenuItem value={30}>30 minutes</MenuItem>
-                <MenuItem value={60}>1 hour</MenuItem>
-              </Select>
-            </FormControl>
-          </ListItemSecondaryAction>
-        </ListItem>
-      </List>
-      <Divider />
       {principals.length > 1 ?
         <><List
           component="nav"
@@ -284,6 +259,31 @@ function Settings(props) {
         </List>
         <Divider /> </>: "" }
         
+      <List component="nav" subheader={<ListSubheader>Preferences</ListSubheader>}>
+        <ListItem>
+          <ListItemText primary="Auto-lock" secondary="Lock the wallet after this much inactivity" />
+          <ListItemSecondaryAction>
+            <FormControl size="small" variant="outlined" style={{minWidth: 130}}>
+              <Select
+                value={autoLock}
+                onChange={(e) => {
+                  setAutoLock(e.target.value);
+                  try { localStorage.setItem('stoic-autolock', String(e.target.value)); } catch (err) {}
+                }}
+                inputProps={{'aria-label': 'Auto-lock timeout'}}
+              >
+                <MenuItem value={0}>Never</MenuItem>
+                <MenuItem value={1}>1 minute</MenuItem>
+                <MenuItem value={5}>5 minutes</MenuItem>
+                <MenuItem value={15}>15 minutes</MenuItem>
+                <MenuItem value={30}>30 minutes</MenuItem>
+                <MenuItem value={60}>1 hour</MenuItem>
+              </Select>
+            </FormControl>
+          </ListItemSecondaryAction>
+        </ListItem>
+      </List>
+      <Divider />
       <ConnectList add handler={connectList} />
       <Divider />
       


### PR DESCRIPTION
- **Receive (QR) icon** moved to sit next to the **edit** and **explorer** icons on the right of the account name (was next to the address copy button).
- **Settings**: moved the **Preferences** section to **below Other Principals**.

Verified: build + headless smoke pass.