### PR TITLE
ui: fixed-height token cards + truncate long names/tickers

### DIFF
--- a/src/components/TokenCard.js
+++ b/src/components/TokenCard.js
@@ -27,12 +27,14 @@ const styles = {
     height: '100%',
   },
   selectedCard: {
-    height: '100%',
+    height: 132,
+    overflow: 'hidden',
     backgroundColor: '#003240',
     color: 'white',
   },
   card: {
-    height: '100%',
+    height: 132,
+    overflow: 'hidden',
   },
   title: {
     fontSize: 14,
@@ -90,10 +92,11 @@ function TokenCard(props) {
               style={styles.title}
               color={props.selected ? 'inherit' : 'textSecondary'}
               gutterBottom
+              noWrap
             >
               {props.data.name}
             </Typography>
-            <Typography variant="h6">
+            <Typography variant="h6" noWrap>
               {balance === false ? 'Loading' : hideBalances ? '••••••' : balance + ' ' + props.data.symbol}
             </Typography>
             {usd && balance !== false && !hideBalances && props.data.symbol === 'ICP' ? (


### PR DESCRIPTION
- **All token cards now share a fixed height** so the grid lines up neatly regardless of content (USD line, loading state, etc.).
- **Long token names and tickers** (e.g. `BDOS.ABCS.ABCD.ABCD`) now **truncate with an ellipsis** on a single line instead of wrapping to two lines and making the card taller.

Verified: build + headless smoke pass.

> Touches `TokenCard.js`, which #198 (balance-fetch reliability) also edits — different lines, should auto-merge; ping me if GitHub flags a conflict.
