### PR TITLE
Resolve #209: Hover over token cards

### DIFF
--- a/src/components/TokenCard.js
+++ b/src/components/TokenCard.js
@@ -44,6 +44,9 @@ const styles = {
     height: 132,
     overflow: 'hidden',
   },
+  actionArea: {
+    height: '100%',
+  },
   title: {
     fontSize: 14,
   },
@@ -94,7 +97,7 @@ function TokenCard(props) {
   return (
     <Grid style={styles.root} item xs={6} sm={4} md={4} lg={3} xl={2}>
       <Card onClick={handleClick} style={props.selected ? styles.selectedCard : styles.card}>
-        <CardActionArea>
+        <CardActionArea style={styles.actionArea}>
           <CardContent>
             <Typography
               style={styles.title}


### PR DESCRIPTION
Resolves #209.

## Agent summary
All 40 tests pass (the findDOMNode warnings are pre-existing and unrelated). The change is complete.

## Summary
Fixed issue #209: the token card hover highlight only covered the top portion. The `CardActionArea` in `src/components/TokenCard.js` wrapped only the content, so its hover/ripple highlight didn't fill the fixed 132px card height. I added an `actionArea` style with `height: '100%'` and applied it to `CardActionArea` so the highlight now spans the entire card.

Test command: `CI=true heavy npm test` — result: 11 suites / 40 tests passed (warnings shown are pre-existing `findDOMNode` deprecation notices, unrelated to this change).

---
_Opened automatically by the agentops worker. Cost: $0.2056, 10 turns._