### PR TITLE
Resolve #210: Darkmode black text

### DIFF
--- a/src/views/AccountDetail.js
+++ b/src/views/AccountDetail.js
@@ -541,7 +541,7 @@ function AccountDetail(props) {
         </Grid>
       </div>
       {currentToken !== 0 && currentToken !== 'nft' && currentToken !== 'other' ? (
-        <div style={{marginLeft: '15px', color: 'rgba(0, 0, 0, 0.54)'}}>
+        <div style={{marginLeft: '15px', color: theme.palette.text.secondary}}>
           <strong>Token ID:</strong> {account.tokens[currentToken].id}
           <SnackbarButton
             message="Token ID Copied"


### PR DESCRIPTION
Resolves #210.

## Agent summary
All 40 tests pass across 11 suites (the stack traces are pre-existing console warnings, not failures).

## Summary
Fixed issue #210 (dark mode black text on Token ID). In `src/views/AccountDetail.js`, the Token ID line for non-ICP/added tokens used a hardcoded `color: 'rgba(0, 0, 0, 0.54)'`, which stayed black in dark mode. Replaced it with the theme-aware `theme.palette.text.secondary` (the `theme` from `useTheme()` is already in scope), so the text adapts to light/dark mode while keeping the same secondary-text appearance in light mode.

Test command: `CI=true heavy npm test` → Test Suites: 11 passed, Tests: 40 passed.

---
_Opened automatically by the agentops worker. Cost: $0.2114, 10 turns._