### PR TITLE
Resolve #214: Token details on token cards are at the top

### DIFF
--- a/src/components/TokenCard.js
+++ b/src/components/TokenCard.js
@@ -46,6 +46,9 @@ const styles = {
   },
   actionArea: {
     height: '100%',
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center',
   },
   title: {
     fontSize: 14,


### PR DESCRIPTION
Resolves #214.

## Agent summary
The build failure is a pre-existing ESLint error in `src/ic/utils.js` (an unused `BigInt` import) — an unrelated file I did not touch. `CI=true` treats lint warnings as errors. My change in `TokenCard.js` is unaffected, and all tests pass.

## Summary

**What changed:** In `src/components/TokenCard.js`, I added `display: flex`, `flexDirection: column`, and `justifyContent: center` to the `actionArea` style. The card has a fixed height of 132px, but its content (`CardContent`) previously sat at the top, leaving the token name/balance crowded at the top with empty space below.

**Why:** This vertically centers the token details within the card, resolving issue #214 where details appeared aligned to the top.

**Tests:** Ran `heavy bash -c "CI=true npm test"` → all 11 test suites / 40 tests passed. The build (`npm run build`) fails only on a pre-existing, unrelated ESLint warning (`BigInt` unused in `src/ic/utils.js`), not from my change.

---
_Opened automatically by the agentops worker. Cost: $0.2025, 8 turns._